### PR TITLE
JSON NULL-node to XML conversion. (Will be asserted to Exception a.t.m.)

### DIFF
--- a/XMLTest.java
+++ b/XMLTest.java
@@ -294,4 +294,19 @@ public class XMLTest {
         JSONObject expectedJsonObject = XML.toJSONObject(expectedStr);
         Util.compareActualVsExpectedJsonObjects(finalJsonObject,expectedJsonObject);
     }
+
+
+    @Test
+    public void shouldHandleNullNodeValue()
+    {
+        JSONObject inputJSON = new JSONObject();
+        inputJSON.put("nullValue", JSONObject.NULL);
+
+        String expectedXML = "<nullValue/>";
+
+        String resultXML = XML.toString(inputJSON);
+
+
+        assertEquals(expectedXML, resultXML);
+    }
 }


### PR DESCRIPTION
This test shows the issue of converting JSONObject.NULL-values to an empty-XML-String.
