### PR TITLE
Complete unit tests for XML.toJSONObjectReader()

### DIFF
--- a/XMLTest.java
+++ b/XMLTest.java
@@ -16,7 +16,7 @@ import org.junit.rules.*;
 public class XMLTest {
     /**
      * JUnit supports temporary files and folders that are cleaned up after the test.
-     * https://garygregory.wordpress.com/2010/01/20/junit-tip-use-rules-to-manage-temporary-files-and-folders/ 
+     * https://garygregory.wordpress.com/2010/01/20/junit-tip-use-rules-to-manage-temporary-files-and-folders/
      */
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
@@ -25,7 +25,7 @@ public class XMLTest {
      * JSONObject from a null XML string.
      * Expects a NullPointerException
      */
-    @Test(expected=NullPointerException.class)
+    @Test(expected = NullPointerException.class)
     public void shouldHandleNullXML() {
         compareStringToJSONObject(null, "");
     }
@@ -54,22 +54,22 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleInvalidSlashInTag() {
-        String xmlStr = 
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
-            "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""+
-            "   xsi:noNamespaceSchemaLocation='test.xsd'>\n"+
-            "    <address>\n"+
-            "       <name/x>\n"+
-            "       <street>abc street</street>\n"+
-            "   </address>\n"+
-            "</addresses>";
+        String xmlStr =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                        "   xsi:noNamespaceSchemaLocation='test.xsd'>\n" +
+                        "    <address>\n" +
+                        "       <name/x>\n" +
+                        "       <street>abc street</street>\n" +
+                        "   </address>\n" +
+                        "</addresses>";
         try {
             XML.toJSONObject(xmlStr);
             assertTrue("Expecting a JSONException", false);
         } catch (JSONException e) {
             assertTrue("Expecting an exception message",
                     "Misshaped tag at 176 [character 14 line 5]".
-                    equals(e.getMessage()));
+                            equals(e.getMessage()));
         }
     }
 
@@ -80,22 +80,22 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleInvalidSlashInTagWithReader() {
-        String xmlStr = 
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
-            "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""+
-            "   xsi:noNamespaceSchemaLocation='test.xsd'>\n"+
-            "    <address>\n"+
-            "       <name/x>\n"+
-            "       <street>abc street</street>\n"+
-            "   </address>\n"+
-            "</addresses>";
+        String xmlStr =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                        "   xsi:noNamespaceSchemaLocation='test.xsd'>\n" +
+                        "    <address>\n" +
+                        "       <name/x>\n" +
+                        "       <street>abc street</street>\n" +
+                        "   </address>\n" +
+                        "</addresses>";
         try {
             XML.toJSONObject(new StringReader(xmlStr));
             assertTrue("Expecting a JSONException", false);
         } catch (JSONException e) {
             assertTrue("Expecting an exception message",
                     "Misshaped tag at 176 [character 14 line 5]".
-                    equals(e.getMessage()));
+                            equals(e.getMessage()));
         }
     }
 
@@ -105,22 +105,22 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleInvalidBangInTag() {
-        String xmlStr = 
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
-            "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""+
-            "   xsi:noNamespaceSchemaLocation='test.xsd'>\n"+
-            "    <address>\n"+
-            "       <name/>\n"+
-            "       <!>\n"+
-            "   </address>\n"+
-            "</addresses>";
+        String xmlStr =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                        "   xsi:noNamespaceSchemaLocation='test.xsd'>\n" +
+                        "    <address>\n" +
+                        "       <name/>\n" +
+                        "       <!>\n" +
+                        "   </address>\n" +
+                        "</addresses>";
         try {
             XML.toJSONObject(xmlStr);
             assertTrue("Expecting a JSONException", false);
         } catch (JSONException e) {
             assertTrue("Expecting an exception message",
                     "Misshaped meta tag at 215 [character 13 line 8]".
-                    equals(e.getMessage()));
+                            equals(e.getMessage()));
         }
     }
 
@@ -130,22 +130,22 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleInvalidBangInTagWithReader() {
-        String xmlStr = 
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
-            "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""+
-            "   xsi:noNamespaceSchemaLocation='test.xsd'>\n"+
-            "    <address>\n"+
-            "       <name/>\n"+
-            "       <!>\n"+
-            "   </address>\n"+
-            "</addresses>";
+        String xmlStr =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                        "   xsi:noNamespaceSchemaLocation='test.xsd'>\n" +
+                        "    <address>\n" +
+                        "       <name/>\n" +
+                        "       <!>\n" +
+                        "   </address>\n" +
+                        "</addresses>";
         try {
             XML.toJSONObject(xmlStr);
             assertTrue("Expecting a JSONException", false);
         } catch (JSONException e) {
             assertTrue("Expecting an exception message",
                     "Misshaped meta tag at 215 [character 13 line 8]".
-                    equals(e.getMessage()));
+                            equals(e.getMessage()));
         }
     }
 
@@ -155,22 +155,22 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleInvalidBangNoCloseInTagWithReader() {
-        String xmlStr = 
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
-            "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""+
-            "   xsi:noNamespaceSchemaLocation='test.xsd'>\n"+
-            "    <address>\n"+
-            "       <name/>\n"+
-            "       <!\n"+
-            "   </address>\n"+
-            "</addresses>";
+        String xmlStr =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                        "   xsi:noNamespaceSchemaLocation='test.xsd'>\n" +
+                        "    <address>\n" +
+                        "       <name/>\n" +
+                        "       <!\n" +
+                        "   </address>\n" +
+                        "</addresses>";
         try {
             XML.toJSONObject(xmlStr);
             assertTrue("Expecting a JSONException", false);
         } catch (JSONException e) {
             assertTrue("Expecting an exception message",
                     "Misshaped meta tag at 214 [character 13 line 8]".
-                    equals(e.getMessage()));
+                            equals(e.getMessage()));
         }
     }
 
@@ -180,22 +180,22 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleNoCloseStartTag() {
-        String xmlStr = 
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
-            "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""+
-            "   xsi:noNamespaceSchemaLocation='test.xsd'>\n"+
-            "    <address>\n"+
-            "       <name/>\n"+
-            "       <abc\n"+
-            "   </address>\n"+
-            "</addresses>";
+        String xmlStr =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                        "   xsi:noNamespaceSchemaLocation='test.xsd'>\n" +
+                        "    <address>\n" +
+                        "       <name/>\n" +
+                        "       <abc\n" +
+                        "   </address>\n" +
+                        "</addresses>";
         try {
             XML.toJSONObject(xmlStr);
             assertTrue("Expecting a JSONException", false);
         } catch (JSONException e) {
             assertTrue("Expecting an exception message",
                     "Misplaced '<' at 193 [character 4 line 7]".
-                    equals(e.getMessage()));
+                            equals(e.getMessage()));
         }
     }
 
@@ -205,22 +205,22 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleNoCloseStartTagWithReader() {
-        String xmlStr = 
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
-            "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""+
-            "   xsi:noNamespaceSchemaLocation='test.xsd'>\n"+
-            "    <address>\n"+
-            "       <name/>\n"+
-            "       <abc\n"+
-            "   </address>\n"+
-            "</addresses>";
+        String xmlStr =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                        "   xsi:noNamespaceSchemaLocation='test.xsd'>\n" +
+                        "    <address>\n" +
+                        "       <name/>\n" +
+                        "       <abc\n" +
+                        "   </address>\n" +
+                        "</addresses>";
         try {
             XML.toJSONObject(new StringReader(xmlStr));
             assertTrue("Expecting a JSONException", false);
         } catch (JSONException e) {
             assertTrue("Expecting an exception message",
                     "Misplaced '<' at 193 [character 4 line 7]".
-                    equals(e.getMessage()));
+                            equals(e.getMessage()));
         }
     }
 
@@ -231,22 +231,22 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleInvalidCDATABangInTag() {
-        String xmlStr = 
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
-            "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""+
-            "   xsi:noNamespaceSchemaLocation='test.xsd'>\n"+
-            "    <address>\n"+
-            "       <name>Joe Tester</name>\n"+
-            "       <![[]>\n"+
-            "   </address>\n"+
-            "</addresses>";
+        String xmlStr =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                        "   xsi:noNamespaceSchemaLocation='test.xsd'>\n" +
+                        "    <address>\n" +
+                        "       <name>Joe Tester</name>\n" +
+                        "       <![[]>\n" +
+                        "   </address>\n" +
+                        "</addresses>";
         try {
             XML.toJSONObject(xmlStr);
             assertTrue("Expecting a JSONException", false);
         } catch (JSONException e) {
             assertTrue("Expecting an exception message",
                     "Expected 'CDATA[' at 204 [character 11 line 6]".
-                    equals(e.getMessage()));
+                            equals(e.getMessage()));
         }
     }
 
@@ -256,22 +256,22 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleInvalidCDATABangInTagWithReader() {
-        String xmlStr = 
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
-            "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""+
-            "   xsi:noNamespaceSchemaLocation='test.xsd'>\n"+
-            "    <address>\n"+
-            "       <name>Joe Tester</name>\n"+
-            "       <![[]>\n"+
-            "   </address>\n"+
-            "</addresses>";
+        String xmlStr =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                        "   xsi:noNamespaceSchemaLocation='test.xsd'>\n" +
+                        "    <address>\n" +
+                        "       <name>Joe Tester</name>\n" +
+                        "       <![[]>\n" +
+                        "   </address>\n" +
+                        "</addresses>";
         try {
             XML.toJSONObject(new StringReader(xmlStr));
             assertTrue("Expecting a JSONException", false);
         } catch (JSONException e) {
             assertTrue("Expecting an exception message",
                     "Expected 'CDATA[' at 204 [character 11 line 6]".
-                    equals(e.getMessage()));
+                            equals(e.getMessage()));
         }
     }
 
@@ -280,9 +280,9 @@ public class XMLTest {
      * Null JSONObject in XML.toString()
      * Expects NullPointerException
      */
-    @Test(expected=NullPointerException.class)
+    @Test(expected = NullPointerException.class)
     public void shouldHandleNullJSONXML() {
-        JSONObject jsonObject= null;
+        JSONObject jsonObject = null;
         XML.toString(jsonObject);
     }
 
@@ -291,7 +291,7 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleEmptyJSONXML() {
-        JSONObject jsonObject= new JSONObject();
+        JSONObject jsonObject = new JSONObject();
         String xmlStr = XML.toString(jsonObject);
         assertTrue("xml string should be empty", xmlStr.length() == 0);
     }
@@ -301,20 +301,20 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleNoStartTag() {
-        String xmlStr = 
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
-            "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""+
-            "   xsi:noNamespaceSchemaLocation='test.xsd'>\n"+
-            "    <address>\n"+
-            "       <name/>\n"+
-            "       <nocontent/>>\n"+
-            "   </address>\n"+
-            "</addresses>";
-        String expectedStr = 
-            "{\"addresses\":{\"address\":{\"name\":\"\",\"nocontent\":\"\",\""+
-            "content\":\">\"},\"xsi:noNamespaceSchemaLocation\":\"test.xsd\",\""+
-            "xmlns:xsi\":\"http://www.w3.org/2001/XMLSchema-instance\"}}";
-         
+        String xmlStr =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                        "   xsi:noNamespaceSchemaLocation='test.xsd'>\n" +
+                        "    <address>\n" +
+                        "       <name/>\n" +
+                        "       <nocontent/>>\n" +
+                        "   </address>\n" +
+                        "</addresses>";
+        String expectedStr =
+                "{\"addresses\":{\"address\":{\"name\":\"\",\"nocontent\":\"\",\"" +
+                        "content\":\">\"},\"xsi:noNamespaceSchemaLocation\":\"test.xsd\",\"" +
+                        "xmlns:xsi\":\"http://www.w3.org/2001/XMLSchema-instance\"}}";
+
         compareStringToJSONObject(xmlStr, expectedStr);
         compareReaderToJSONObject(xmlStr, expectedStr);
         compareFileToJSONObject(xmlStr, expectedStr);
@@ -325,34 +325,34 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleSimpleXML() {
-        String xmlStr = 
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
-            "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""+
-            "   xsi:noNamespaceSchemaLocation='test.xsd'>\n"+
-            "   <address>\n"+
-            "       <name>Joe Tester</name>\n"+
-            "       <street>[CDATA[Baker street 5]</street>\n"+
-            "       <NothingHere/>\n"+
-            "       <TrueValue>true</TrueValue>\n"+
-            "       <FalseValue>false</FalseValue>\n"+
-            "       <NullValue>null</NullValue>\n"+
-            "       <PositiveValue>42</PositiveValue>\n"+
-            "       <NegativeValue>-23</NegativeValue>\n"+
-            "       <DoubleValue>-23.45</DoubleValue>\n"+
-            "       <Nan>-23x.45</Nan>\n"+
-            "       <ArrayOfNum>1, 2, 3, 4.1, 5.2</ArrayOfNum>\n"+
-            "   </address>\n"+
-            "</addresses>";
+        String xmlStr =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                        "   xsi:noNamespaceSchemaLocation='test.xsd'>\n" +
+                        "   <address>\n" +
+                        "       <name>Joe Tester</name>\n" +
+                        "       <street>[CDATA[Baker street 5]</street>\n" +
+                        "       <NothingHere/>\n" +
+                        "       <TrueValue>true</TrueValue>\n" +
+                        "       <FalseValue>false</FalseValue>\n" +
+                        "       <NullValue>null</NullValue>\n" +
+                        "       <PositiveValue>42</PositiveValue>\n" +
+                        "       <NegativeValue>-23</NegativeValue>\n" +
+                        "       <DoubleValue>-23.45</DoubleValue>\n" +
+                        "       <Nan>-23x.45</Nan>\n" +
+                        "       <ArrayOfNum>1, 2, 3, 4.1, 5.2</ArrayOfNum>\n" +
+                        "   </address>\n" +
+                        "</addresses>";
 
-        String expectedStr = 
-            "{\"addresses\":{\"address\":{\"street\":\"[CDATA[Baker street 5]\","+
-            "\"name\":\"Joe Tester\",\"NothingHere\":\"\",TrueValue:true,\n"+
-            "\"FalseValue\":false,\"NullValue\":null,\"PositiveValue\":42,\n"+
-            "\"NegativeValue\":-23,\"DoubleValue\":-23.45,\"Nan\":-23x.45,\n"+
-            "\"ArrayOfNum\":\"1, 2, 3, 4.1, 5.2\"\n"+
-            "},\"xsi:noNamespaceSchemaLocation\":"+
-            "\"test.xsd\",\"xmlns:xsi\":\"http://www.w3.org/2001/"+
-            "XMLSchema-instance\"}}";
+        String expectedStr =
+                "{\"addresses\":{\"address\":{\"street\":\"[CDATA[Baker street 5]\"," +
+                        "\"name\":\"Joe Tester\",\"NothingHere\":\"\",TrueValue:true,\n" +
+                        "\"FalseValue\":false,\"NullValue\":null,\"PositiveValue\":42,\n" +
+                        "\"NegativeValue\":-23,\"DoubleValue\":-23.45,\"Nan\":-23x.45,\n" +
+                        "\"ArrayOfNum\":\"1, 2, 3, 4.1, 5.2\"\n" +
+                        "},\"xsi:noNamespaceSchemaLocation\":" +
+                        "\"test.xsd\",\"xmlns:xsi\":\"http://www.w3.org/2001/" +
+                        "XMLSchema-instance\"}}";
 
         compareStringToJSONObject(xmlStr, expectedStr);
         compareReaderToJSONObject(xmlStr, expectedStr);
@@ -365,21 +365,21 @@ public class XMLTest {
     @Test
     public void shouldHandleCommentsInXML() {
 
-        String xmlStr = 
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
-                "<!-- this is a comment -->\n"+
-                "<addresses>\n"+
-                "   <address>\n"+
-                "       <![CDATA[ this is -- <another> comment ]]>\n"+
-                "       <name>Joe Tester</name>\n"+
-                "       <!-- this is a - multi line \n"+
-                "            comment -->\n"+
-                "       <street>Baker street 5</street>\n"+
-                "   </address>\n"+
-                "</addresses>";
+        String xmlStr =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<!-- this is a comment -->\n" +
+                        "<addresses>\n" +
+                        "   <address>\n" +
+                        "       <![CDATA[ this is -- <another> comment ]]>\n" +
+                        "       <name>Joe Tester</name>\n" +
+                        "       <!-- this is a - multi line \n" +
+                        "            comment -->\n" +
+                        "       <street>Baker street 5</street>\n" +
+                        "   </address>\n" +
+                        "</addresses>";
 
-        String expectedStr = "{\"addresses\":{\"address\":{\"street\":\"Baker "+
-                "street 5\",\"name\":\"Joe Tester\",\"content\":\" this is -- "+
+        String expectedStr = "{\"addresses\":{\"address\":{\"street\":\"Baker " +
+                "street 5\",\"name\":\"Joe Tester\",\"content\":\" this is -- " +
                 "<another> comment \"}}}";
 
         compareStringToJSONObject(xmlStr, expectedStr);
@@ -392,25 +392,32 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleToString() {
-        String xmlStr = 
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"+
-            "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""+
-            "   xsi:noNamespaceSchemaLocation='test.xsd'>\n"+
-            "   <address>\n"+
-            "       <name>[CDATA[Joe &amp; T &gt; e &lt; s &quot; t &apos; er]]</name>\n"+
-            "       <street>Baker street 5</street>\n"+
-            "       <ArrayOfNum>1, 2, 3, 4.1, 5.2</ArrayOfNum>\n"+
-            "   </address>\n"+
-            "</addresses>";
+        String xmlStr =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<addresses xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
+                        "   xsi:noNamespaceSchemaLocation='test.xsd'>\n" +
+                        "   <address>\n" +
+                        "       <name>[CDATA[Joe &amp; T &gt; e &lt; s &quot; t &apos; er]]</name>\n" +
+                        "       <street>Baker street 5</street>\n" +
+                        "       <ArrayOfNum>1, 2, 3, 4.1, 5.2</ArrayOfNum>\n" +
+                        "   </address>\n" +
+                        "</addresses>";
 
-        String expectedStr = 
-                "{\"addresses\":{\"address\":{\"street\":\"Baker street 5\","+
-                "\"name\":\"[CDATA[Joe & T > e < s \\\" t \\\' er]]\","+
-                "\"ArrayOfNum\":\"1, 2, 3, 4.1, 5.2\"\n"+
-                "},\"xsi:noNamespaceSchemaLocation\":"+
-                "\"test.xsd\",\"xmlns:xsi\":\"http://www.w3.org/2001/"+
-                "XMLSchema-instance\"}}";
-        
+        String expectedStr =
+                "{\"addresses\":{\"address\":{\"street\":\"Baker street 5\"," +
+                        "\"name\":\"[CDATA[Joe & T > e < s \\\" t \\\' er]]\"," +
+                        "\"ArrayOfNum\":\"1, 2, 3, 4.1, 5.2\"\n" +
+                        "},\"xsi:noNamespaceSchemaLocation\":" +
+                        "\"test.xsd\",\"xmlns:xsi\":\"http://www.w3.org/2001/" +
+                        "XMLSchema-instance\"}}";
+
+        JSONObject jsonObject = XML.toJSONObject(xmlStr);
+        String xmlToStr = XML.toString(jsonObject);
+
+        compareStringToJSONObject(xmlToStr, expectedStr);
+        compareReaderToJSONObject(xmlToStr, expectedStr);
+        compareFileToJSONObject(xmlToStr, expectedStr);
+
         compareStringToJSONObject(xmlStr, expectedStr);
         compareReaderToJSONObject(xmlStr, expectedStr);
         compareFileToJSONObject(xmlStr, expectedStr);
@@ -422,19 +429,19 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleContentNoArraytoString() {
-        String expectedStr = 
-            "{\"addresses\":{\"address\":{\"name\":\"\",\"nocontent\":\"\",\""+
-            "content\":\">\"},\"xsi:noNamespaceSchemaLocation\":\"test.xsd\",\""+
-            "xmlns:xsi\":\"http://www.w3.org/2001/XMLSchema-instance\"}}";
-
-        String expectedFinalStr = "<addresses><address><name/><nocontent/>&gt;"+
-                "</address><xsi:noNamespaceSchemaLocation>test.xsd</xsi:noName"+
-                "spaceSchemaLocation><xmlns:xsi>http://www.w3.org/2001/XMLSche"+
+        String expectedStr =
+                "{\"addresses\":{\"address\":{\"name\":\"\",\"nocontent\":\"\",\"" +
+                        "content\":\">\"},\"xsi:noNamespaceSchemaLocation\":\"test.xsd\",\"" +
+                        "xmlns:xsi\":\"http://www.w3.org/2001/XMLSchema-instance\"}}";
+        JSONObject expectedJsonObject = new JSONObject(expectedStr);
+        String finalStr = XML.toString(expectedJsonObject);
+        String expectedFinalStr = "<addresses><address><name/><nocontent/>&gt;" +
+                "</address><xsi:noNamespaceSchemaLocation>test.xsd</xsi:noName" +
+                "spaceSchemaLocation><xmlns:xsi>http://www.w3.org/2001/XMLSche" +
                 "ma-instance</xmlns:xsi></addresses>";
 
-        compareStringToJSONObject(xmlStr, expectedStr);
-        compareReaderToJSONObject(xmlStr, expectedStr);
-        compareFileToJSONObject(xmlStr, expectedStr);
+        assertTrue("Should handle expectedFinal: [" + expectedStr + "] final: [" +
+                finalStr + "]", expectedFinalStr.equals(finalStr));
     }
 
     /**
@@ -444,20 +451,20 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleContentArraytoString() {
-        String expectedStr = 
-            "{\"addresses\":{\"address\":{\"name\":\"\",\"nocontent\":\"\",\""+
-            "content\":[1, 2, 3]},\"xsi:noNamespaceSchemaLocation\":\"test.xsd\",\""+
-            "xmlns:xsi\":\"http://www.w3.org/2001/XMLSchema-instance\"}}";
-
-        String expectedFinalStr = "<addresses><address><name/><nocontent/>"+
-                "1\n2\n3"+
-                "</address><xsi:noNamespaceSchemaLocation>test.xsd</xsi:noName"+
-                "spaceSchemaLocation><xmlns:xsi>http://www.w3.org/2001/XMLSche"+
+        String expectedStr =
+                "{\"addresses\":{\"address\":{\"name\":\"\",\"nocontent\":\"\",\"" +
+                        "content\":[1, 2, 3]},\"xsi:noNamespaceSchemaLocation\":\"test.xsd\",\"" +
+                        "xmlns:xsi\":\"http://www.w3.org/2001/XMLSchema-instance\"}}";
+        JSONObject expectedJsonObject = new JSONObject(expectedStr);
+        String finalStr = XML.toString(expectedJsonObject);
+        String expectedFinalStr = "<addresses><address><name/><nocontent/>" +
+                "1\n2\n3" +
+                "</address><xsi:noNamespaceSchemaLocation>test.xsd</xsi:noName" +
+                "spaceSchemaLocation><xmlns:xsi>http://www.w3.org/2001/XMLSche" +
                 "ma-instance</xmlns:xsi></addresses>";
 
-        compareStringToJSONObject(xmlStr, expectedStr);
-        compareReaderToJSONObject(xmlStr, expectedStr);
-        compareFileToJSONObject(xmlStr, expectedStr);
+        assertTrue("Should handle expectedFinal: [" + expectedStr + "] final: [" +
+                finalStr + "]", expectedFinalStr.equals(finalStr));
     }
 
     /**
@@ -466,19 +473,20 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleArraytoString() {
-        String expectedStr = 
-            "{\"addresses\":{\"address\":{\"name\":\"\",\"nocontent\":\"\","+
-            "\"something\":[1, 2, 3]},\"xsi:noNamespaceSchemaLocation\":\"test.xsd\",\""+
-
-        String expectedFinalStr = "<addresses><address><name/><nocontent/>"+
-                "<something>1</something><something>2</something><something>3</something>"+
-                "</address><xsi:noNamespaceSchemaLocation>test.xsd</xsi:noName"+
-                "spaceSchemaLocation><xmlns:xsi>http://www.w3.org/2001/XMLSche"+
+        String expectedStr =
+                "{\"addresses\":{\"address\":{\"name\":\"\",\"nocontent\":\"\"," +
+                        "\"something\":[1, 2, 3]},\"xsi:noNamespaceSchemaLocation\":\"test.xsd\",\"" +
+                        "xmlns:xsi\":\"http://www.w3.org/2001/XMLSchema-instance\"}}";
+        JSONObject expectedJsonObject = new JSONObject(expectedStr);
+        String finalStr = XML.toString(expectedJsonObject);
+        String expectedFinalStr = "<addresses><address><name/><nocontent/>" +
+                "<something>1</something><something>2</something><something>3</something>" +
+                "</address><xsi:noNamespaceSchemaLocation>test.xsd</xsi:noName" +
+                "spaceSchemaLocation><xmlns:xsi>http://www.w3.org/2001/XMLSche" +
                 "ma-instance</xmlns:xsi></addresses>";
 
-        compareStringToJSONObject(xmlStr, expectedStr);
-        compareReaderToJSONObject(xmlStr, expectedStr);
-        compareFileToJSONObject(xmlStr, expectedStr);
+        assertTrue("Should handle expectedFinal: [" + expectedStr + "] final: [" +
+                finalStr + "]", expectedFinalStr.equals(finalStr));
     }
 
     /**
@@ -487,16 +495,16 @@ public class XMLTest {
      */
     @Test
     public void shouldHandleNestedArraytoString() {
-        String xmlStr = 
-            "{\"addresses\":{\"address\":{\"name\":\"\",\"nocontent\":\"\","+
-            "\"outer\":[[1], [2], [3]]},\"xsi:noNamespaceSchemaLocation\":\"test.xsd\",\""+
-            "xmlns:xsi\":\"http://www.w3.org/2001/XMLSchema-instance\"}}";
+        String xmlStr =
+                "{\"addresses\":{\"address\":{\"name\":\"\",\"nocontent\":\"\"," +
+                        "\"outer\":[[1], [2], [3]]},\"xsi:noNamespaceSchemaLocation\":\"test.xsd\",\"" +
+                        "xmlns:xsi\":\"http://www.w3.org/2001/XMLSchema-instance\"}}";
 
-        String expectedStr = "<addresses><address><name/><nocontent/>"+
-                "<outer><array>1</array></outer><outer><array>2</array>"+
-                "</outer><outer><array>3</array></outer>"+
-                "</address><xsi:noNamespaceSchemaLocation>test.xsd</xsi:noName"+
-                "spaceSchemaLocation><xmlns:xsi>http://www.w3.org/2001/XMLSche"+
+        String expectedStr = "<addresses><address><name/><nocontent/>" +
+                "<outer><array>1</array></outer><outer><array>2</array>" +
+                "</outer><outer><array>3</array></outer>" +
+                "</address><xsi:noNamespaceSchemaLocation>test.xsd</xsi:noName" +
+                "spaceSchemaLocation><xmlns:xsi>http://www.w3.org/2001/XMLSche" +
                 "ma-instance</xmlns:xsi></addresses>";
 
         compareStringToJSONObject(xmlStr, expectedStr);
@@ -506,14 +514,13 @@ public class XMLTest {
 
 
     /**
-     * Possible bug: 
+     * Possible bug:
      * Illegal node-names must be converted to legal XML-node-names.
      * The given example shows 2 nodes which are valid for JSON, but not for XML.
      * Therefore illegal arguments should be converted to e.g. an underscore (_).
      */
     @Test
-    public void shouldHandleIllegalJSONNodeNames()
-    {
+    public void shouldHandleIllegalJSONNodeNames() {
         JSONObject inputJSON = new JSONObject();
         inputJSON.append("123IllegalNode", "someValue1");
         inputJSON.append("Illegal@node", "someValue2");
@@ -535,8 +542,7 @@ public class XMLTest {
      * JSONObject with NULL value, to XML.toString()
      */
     @Test
-    public void shouldHandleNullNodeValue()
-    {
+    public void shouldHandleNullNodeValue() {
         JSONObject inputJSON = new JSONObject();
         inputJSON.put("nullValue", JSONObject.NULL);
         // This is a possible preferred result
@@ -567,7 +573,7 @@ public class XMLTest {
         assertTrue("1. content found", "if (a < b && a > 0) then return".equals(jsonObject.get("content")));
 
         // Same tests, but for XML.toJSONObject(Reader)
-        JSONObject jsonObject = XML.toJSONObject(new StringReader(xmlStr));
+        jsonObject = XML.toJSONObject(new StringReader(xmlStr));
         assertTrue("1. 3 items", 3 == jsonObject.length());
         assertTrue("1. empty tag1", "".equals(jsonObject.get("tag1")));
         assertTrue("1. empty tag2", "".equals(jsonObject.get("tag2")));
@@ -592,7 +598,7 @@ public class XMLTest {
         assertTrue("2. empty tag1", "".equals(jsonObject.get("tag1")));
         assertTrue("2. empty tag2", "".equals(jsonObject.get("tag2")));
         assertTrue("2. content array found", jsonObject.get("content") instanceof JSONArray);
-        JSONArray jsonArray = jsonObject.getJSONArray("content");
+        jsonArray = jsonObject.getJSONArray("content");
         assertTrue("2. array size", jsonArray.length() == 2);
         assertTrue("2. content array entry 0", "if (a < b && a > 0) then return".equals(jsonArray.get(0)));
         assertTrue("2. content array entry 1", "here is another cdata".equals(jsonArray.get(1)));
@@ -602,7 +608,7 @@ public class XMLTest {
          * If there is only one instance, it is saved in the context (a different JSONObject 
          * from the calling code. and the content element is discarded. 
          */
-        xmlStr =  "<tag1>value 1</tag1>";
+        xmlStr = "<tag1>value 1</tag1>";
         jsonObject = XML.toJSONObject(xmlStr);
         assertTrue("3. 2 items", 1 == jsonObject.length());
         assertTrue("3. value tag1", "value 1".equals(jsonObject.get("tag1")));
@@ -617,7 +623,7 @@ public class XMLTest {
          * accumulated in a local JSONObject with key="content" and value=JSONArray,
          * saved in the context, and then the local JSONObject is discarded.
          */
-        xmlStr =  "<tag1>value 1</tag1><tag1>2</tag1><tag1>true</tag1>";
+        xmlStr = "<tag1>value 1</tag1><tag1>2</tag1><tag1>true</tag1>";
         jsonObject = XML.toJSONObject(xmlStr);
         assertTrue("4. 1 item", 1 == jsonObject.length());
         assertTrue("4. content array found", jsonObject.get("tag1") instanceof JSONArray);
@@ -641,7 +647,7 @@ public class XMLTest {
          * may contain a mix of child elements and text. Each text segment is 
          * accumulated to content. 
          */
-        xmlStr =  "<tag1>val1<tag2/>val2</tag1>";
+        xmlStr = "<tag1>val1<tag2/>val2</tag1>";
         jsonObject = XML.toJSONObject(xmlStr);
         assertTrue("5. 1 item", 1 == jsonObject.length());
         assertTrue("5. jsonObject found", jsonObject.get("tag1") instanceof JSONObject);
@@ -671,7 +677,7 @@ public class XMLTest {
          * If there is only 1 complex text content, then it is accumulated in a 
          * "content" field as a string.
          */
-        xmlStr =  "<tag1>val1<tag2/></tag1>";
+        xmlStr = "<tag1>val1<tag2/></tag1>";
         jsonObject = XML.toJSONObject(xmlStr);
         assertTrue("6. 1 item", 1 == jsonObject.length());
         assertTrue("6. jsonObject found", jsonObject.get("tag1") instanceof JSONObject);
@@ -692,7 +698,7 @@ public class XMLTest {
          * We end up with an array within an array, and no content element.
          * This is probably a bug. 
          */
-        xmlStr =  "<tag1>val1<content/></tag1>";
+        xmlStr = "<tag1>val1<content/></tag1>";
         jsonObject = XML.toJSONObject(xmlStr);
         assertTrue("7. 1 item", 1 == jsonObject.length());
         assertTrue("7. jsonArray found", jsonObject.get("tag1") instanceof JSONArray);
@@ -720,27 +726,27 @@ public class XMLTest {
         /**
          * Confirm behavior of original issue
          */
-        String jsonStr = 
-                "{"+
-                    "\"Profile\": {"+
-                        "\"list\": {"+
-                            "\"history\": {"+
-                                "\"entries\": ["+
-                                    "{"+
-                                        "\"deviceId\": \"id\","+
-                                        "\"content\": {"+
-                                            "\"material\": ["+
-                                                "{"+
-                                                    "\"stuff\": false"+
-                                                "}"+
-                                            "]"+
-                                        "}"+
-                                    "}"+
-                                "]"+
-                            "}"+
-                        "}"+
-                    "}"+
-                "}";
+        String jsonStr =
+                "{" +
+                        "\"Profile\": {" +
+                        "\"list\": {" +
+                        "\"history\": {" +
+                        "\"entries\": [" +
+                        "{" +
+                        "\"deviceId\": \"id\"," +
+                        "\"content\": {" +
+                        "\"material\": [" +
+                        "{" +
+                        "\"stuff\": false" +
+                        "}" +
+                        "]" +
+                        "}" +
+                        "}" +
+                        "]" +
+                        "}" +
+                        "}" +
+                        "}" +
+                        "}";
         jsonObject = new JSONObject(jsonStr);
         xmlStr = XML.toString(jsonObject);
         /**
@@ -763,34 +769,37 @@ public class XMLTest {
     /**
      * Convenience method, given an input string and expected result,
      * convert to JSONObject and compare actual to expected result.
-     * @param xmlStr the string to parse
+     *
+     * @param xmlStr      the string to parse
      * @param expectedStr the expected JSON string
      */
     private void compareStringToJSONObject(String xmlStr, String expectedStr) {
         JSONObject expectedJsonObject = new JSONObject(expectedStr);
         JSONObject jsonObject = XML.toJSONObject(xmlStr);
-        Util.compareActualVsExpectedJsonObjects(jsonObject,expectedJsonObject);
+        Util.compareActualVsExpectedJsonObjects(jsonObject, expectedJsonObject);
     }
 
     /**
      * Convenience method, given an input string and expected result,
      * convert to JSONObject via reader and compare actual to expected result.
-     * @param xmlStr the string to parse
+     *
+     * @param xmlStr      the string to parse
      * @param expectedStr the expected JSON string
      */
     private void compareReaderToJSONObject(String xmlStr, String expectedStr) {
         JSONObject expectedJsonObject = new JSONObject(expectedStr);
         Reader reader = new StringReader(xmlStr);
         JSONObject jsonObject = XML.toJSONObject(reader);
-        Util.compareActualVsExpectedJsonObjects(jsonObject,expectedJsonObject);
+        Util.compareActualVsExpectedJsonObjects(jsonObject, expectedJsonObject);
     }
 
     /**
      * Convenience method, given an input string and expected result,
      * convert to JSONObject via file and compare actual to expected result.
-     * @param xmlStr the string to parse
+     *
+     * @param xmlStr      the string to parse
      * @param expectedStr the expected JSON string
-     * @throws IOException 
+     * @throws IOException
      */
     private void compareFileToJSONObject(String xmlStr, String expectedStr) {
         try {
@@ -801,9 +810,9 @@ public class XMLTest {
             fileWriter.close();
             Reader reader = new FileReader(tempFile);
             JSONObject jsonObject = XML.toJSONObject(reader);
-            Util.compareActualVsExpectedJsonObjects(jsonObject,expectedJsonObject);
+            Util.compareActualVsExpectedJsonObjects(jsonObject, expectedJsonObject);
         } catch (IOException e) {
-            assertTrue("file writer error: " +e.getMessage(), false);
+            assertTrue("file writer error: " + e.getMessage(), false);
         }
     }
 }


### PR DESCRIPTION
This branch introduces changes that should finish unit tests for `XML.toJSONObjectReader()`.  I have changed many of the tests to start using `compareStringToJSONObject()`,`compareReaderToJSONObject()`, and `compareFileToJSONObject()`.

Tell me what you think.
