### PR TITLE
Replace util compare method with JsonPath

### DIFF
--- a/CookieListTest.java
+++ b/CookieListTest.java
@@ -75,12 +75,10 @@ public class CookieListTest {
     public void simpleCookieList() {
         String cookieStr = "SID=31d4d96e407aad42";
         JSONObject jsonObject = CookieList.toJSONObject(cookieStr);
-        Object doc = Configuration.defaultConfiguration().jsonProvider().
-                parse(jsonObject.toString());
-        assertTrue("Expected 1 top level item",
-                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 1);
-        assertTrue("expected 31d4d96e407aad42",
-                "31d4d96e407aad42".equals(JsonPath.read(doc, "$.SID")));
+        // validate JSON content
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("Expected 1 top level item", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 1);
+        assertTrue("expected 31d4d96e407aad42", "31d4d96e407aad42".equals(JsonPath.read(doc, "$.SID")));
     }
 
     /**
@@ -90,12 +88,10 @@ public class CookieListTest {
     public void simpleCookieListWithDelimiter() {
         String cookieStr = "SID=31d4d96e407aad42;";
         JSONObject jsonObject = CookieList.toJSONObject(cookieStr);
-        Object doc = Configuration.defaultConfiguration().jsonProvider().
-                parse(jsonObject.toString());
-        assertTrue("Expected 1 top level item",
-                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 1);
-        assertTrue("expected 31d4d96e407aad42",
-                "31d4d96e407aad42".equals(JsonPath.read(doc, "$.SID")));
+        // validate JSON content
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("Expected 1 top level item", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 1);
+        assertTrue("expected 31d4d96e407aad42", "31d4d96e407aad42".equals(JsonPath.read(doc, "$.SID")));
     }
 
     /**
@@ -112,22 +108,15 @@ public class CookieListTest {
             "name5=myCookieValue5;"+
             "  name6=myCookieValue6;";
         JSONObject jsonObject = CookieList.toJSONObject(cookieStr);
-        Object doc = Configuration.defaultConfiguration().jsonProvider().
-                parse(jsonObject.toString());
-        assertTrue("Expected 6 top level items",
-                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 6);
-        assertTrue("expected myCookieValue1",
-                "myCookieValue1".equals(JsonPath.read(doc, "$.name1")));
-        assertTrue("expected myCookieValue2",
-                "myCookieValue2".equals(JsonPath.read(doc, "$.name2")));
-        assertTrue("expected myCookieValue3",
-                "myCookieValue3".equals(JsonPath.read(doc, "$.name3")));
-        assertTrue("expected myCookieValue4",
-                "myCookieValue4".equals(JsonPath.read(doc, "$.name4")));
-        assertTrue("expected myCookieValue5",
-                "myCookieValue5".equals(JsonPath.read(doc, "$.name5")));
-        assertTrue("expected myCookieValue6",
-                "myCookieValue6".equals(JsonPath.read(doc, "$.name6")));
+        // validate JSON content
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("Expected 6 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 6);
+        assertTrue("expected myCookieValue1", "myCookieValue1".equals(JsonPath.read(doc, "$.name1")));
+        assertTrue("expected myCookieValue2", "myCookieValue2".equals(JsonPath.read(doc, "$.name2")));
+        assertTrue("expected myCookieValue3", "myCookieValue3".equals(JsonPath.read(doc, "$.name3")));
+        assertTrue("expected myCookieValue4", "myCookieValue4".equals(JsonPath.read(doc, "$.name4")));
+        assertTrue("expected myCookieValue5", "myCookieValue5".equals(JsonPath.read(doc, "$.name5")));
+        assertTrue("expected myCookieValue6", "myCookieValue6".equals(JsonPath.read(doc, "$.name6")));
     }
 
     /**
@@ -154,22 +143,15 @@ public class CookieListTest {
                 "name5=myCookieValue5;"+
                 "  name6=myCookieValue6;";
         JSONObject jsonObject = CookieList.toJSONObject(cookieStr);
-        Object doc = Configuration.defaultConfiguration().jsonProvider().
-                parse(jsonObject.toString());
-        assertTrue("Expected 6 top level items",
-                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 6);
-        assertTrue("expected myCookieValue1",
-                "myCookieValue1".equals(JsonPath.read(doc, "$.name1")));
-        assertTrue("expected myCookieValue2",
-                "myCookieValue2".equals(JsonPath.read(doc, "$.name2")));
-        assertTrue("expected myCookieValue3",
-                "myCookieValue3".equals(JsonPath.read(doc, "$.name3")));
-        assertTrue("expected myCookieValue4",
-                "myCookieValue4".equals(JsonPath.read(doc, "$.name4")));
-        assertTrue("expected myCookieValue5",
-                "myCookieValue5".equals(JsonPath.read(doc, "$.name5")));
-        assertTrue("expected myCookieValue6",
-                "myCookieValue6".equals(JsonPath.read(doc, "$.name6")));
+        // validate JSON content
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("Expected 6 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 6);
+        assertTrue("expected myCookieValue1", "myCookieValue1".equals(JsonPath.read(doc, "$.name1")));
+        assertTrue("expected myCookieValue2", "myCookieValue2".equals(JsonPath.read(doc, "$.name2")));
+        assertTrue("expected myCookieValue3", "myCookieValue3".equals(JsonPath.read(doc, "$.name3")));
+        assertTrue("expected myCookieValue4", "myCookieValue4".equals(JsonPath.read(doc, "$.name4")));
+        assertTrue("expected myCookieValue5", "myCookieValue5".equals(JsonPath.read(doc, "$.name5")));
+        assertTrue("expected myCookieValue6", "myCookieValue6".equals(JsonPath.read(doc, "$.name6")));
     }
 
     /**
@@ -186,21 +168,14 @@ public class CookieListTest {
                 "name5=myCookieValue5;"+
                 "  name6=myCookieValue6;";
         JSONObject jsonObject = CookieList.toJSONObject(cookieStr);
-        Object doc = Configuration.defaultConfiguration().jsonProvider().
-                parse(jsonObject.toString());
-        assertTrue("Expected 6 top level items",
-                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 6);
-        assertTrue("expected myCookieValue1",
-                "myCookieValue1".equals(JsonPath.read(doc, "$.name1")));
-        assertTrue("expected my Cookie Value 2",
-                "my Cookie Value 2".equals(JsonPath.read(doc, "$.name2")));
-        assertTrue("expected my+Cookie&Value;3=",
-                "my+Cookie&Value;3=".equals(JsonPath.read(doc, "$.name3")));
-        assertTrue("expected my%CookieValue4",
-                "my%CookieValue4".equals(JsonPath.read(doc, "$.name4")));
-        assertTrue("expected my%CookieValue5",
-                "myCookieValue5".equals(JsonPath.read(doc, "$.name5")));
-        assertTrue("expected myCookieValue6",
-                "myCookieValue6".equals(JsonPath.read(doc, "$.name6")));
+        // validate JSON content
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("Expected 6 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 6);
+        assertTrue("expected myCookieValue1", "myCookieValue1".equals(JsonPath.read(doc, "$.name1")));
+        assertTrue("expected my Cookie Value 2", "my Cookie Value 2".equals(JsonPath.read(doc, "$.name2")));
+        assertTrue("expected my+Cookie&Value;3=", "my+Cookie&Value;3=".equals(JsonPath.read(doc, "$.name3")));
+        assertTrue("expected my%CookieValue4", "my%CookieValue4".equals(JsonPath.read(doc, "$.name4")));
+        assertTrue("expected my%CookieValue5", "myCookieValue5".equals(JsonPath.read(doc, "$.name5")));
+        assertTrue("expected myCookieValue6", "myCookieValue6".equals(JsonPath.read(doc, "$.name6")));
     }
 }

--- a/CookieListTest.java
+++ b/CookieListTest.java
@@ -2,8 +2,12 @@ package org.json.junit;
 
 import static org.junit.Assert.*;
 
+import java.util.*;
+
 import org.json.*;
 import org.junit.Test;
+
+import com.jayway.jsonpath.*;
 
 /**
  * HTTP cookie specification RFC6265: http://tools.ietf.org/html/rfc6265
@@ -60,7 +64,6 @@ public class CookieListTest {
     @Test
     public void emptyStringCookieList() {
         String cookieStr = "";
-        String expectedCookieStr = "";
         JSONObject jsonObject = CookieList.toJSONObject(cookieStr);
         assertTrue(jsonObject.length() == 0);
     }
@@ -71,10 +74,13 @@ public class CookieListTest {
     @Test
     public void simpleCookieList() {
         String cookieStr = "SID=31d4d96e407aad42";
-        String expectedCookieStr = "{\"SID\":\"31d4d96e407aad42\"}";
         JSONObject jsonObject = CookieList.toJSONObject(cookieStr);
-        JSONObject expectedJsonObject = new JSONObject(expectedCookieStr);
-        Util.compareActualVsExpectedJsonObjects(jsonObject,expectedJsonObject);
+        Object doc = Configuration.defaultConfiguration().jsonProvider().
+                parse(jsonObject.toString());
+        assertTrue("Expected 1 top level item",
+                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 1);
+        assertTrue("expected 31d4d96e407aad42",
+                "31d4d96e407aad42".equals(JsonPath.read(doc, "$.SID")));
     }
 
     /**
@@ -83,10 +89,13 @@ public class CookieListTest {
     @Test
     public void simpleCookieListWithDelimiter() {
         String cookieStr = "SID=31d4d96e407aad42;";
-        String expectedCookieStr = "{\"SID\":\"31d4d96e407aad42\"}";
         JSONObject jsonObject = CookieList.toJSONObject(cookieStr);
-        JSONObject expectedJsonObject = new JSONObject(expectedCookieStr);
-        Util.compareActualVsExpectedJsonObjects(jsonObject,expectedJsonObject);
+        Object doc = Configuration.defaultConfiguration().jsonProvider().
+                parse(jsonObject.toString());
+        assertTrue("Expected 1 top level item",
+                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 1);
+        assertTrue("expected 31d4d96e407aad42",
+                "31d4d96e407aad42".equals(JsonPath.read(doc, "$.SID")));
     }
 
     /**
@@ -102,18 +111,23 @@ public class CookieListTest {
             "  name4=myCookieValue4;  "+
             "name5=myCookieValue5;"+
             "  name6=myCookieValue6;";
-        String expectedCookieStr = 
-            "{"+
-                "\"name1\":\"myCookieValue1\","+
-                "\"name2\":\"myCookieValue2\","+
-                "\"name3\":\"myCookieValue3\","+
-                "\"name4\":\"myCookieValue4\","+
-                "\"name5\":\"myCookieValue5\","+
-                "\"name6\":\"myCookieValue6\""+
-            "}";
         JSONObject jsonObject = CookieList.toJSONObject(cookieStr);
-        JSONObject expectedJsonObject = new JSONObject(expectedCookieStr);
-        Util.compareActualVsExpectedJsonObjects(jsonObject,expectedJsonObject);
+        Object doc = Configuration.defaultConfiguration().jsonProvider().
+                parse(jsonObject.toString());
+        assertTrue("Expected 6 top level items",
+                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 6);
+        assertTrue("expected myCookieValue1",
+                "myCookieValue1".equals(JsonPath.read(doc, "$.name1")));
+        assertTrue("expected myCookieValue2",
+                "myCookieValue2".equals(JsonPath.read(doc, "$.name2")));
+        assertTrue("expected myCookieValue3",
+                "myCookieValue3".equals(JsonPath.read(doc, "$.name3")));
+        assertTrue("expected myCookieValue4",
+                "myCookieValue4".equals(JsonPath.read(doc, "$.name4")));
+        assertTrue("expected myCookieValue5",
+                "myCookieValue5".equals(JsonPath.read(doc, "$.name5")));
+        assertTrue("expected myCookieValue6",
+                "myCookieValue6".equals(JsonPath.read(doc, "$.name6")));
     }
 
     /**
@@ -139,21 +153,23 @@ public class CookieListTest {
                 "  name4=myCookieValue4;  "+
                 "name5=myCookieValue5;"+
                 "  name6=myCookieValue6;";
-            String expectedCookieStr = 
-                "{"+
-                    "\"name1\":\"myCookieValue1\","+
-                    "\"name2\":\"myCookieValue2\","+
-                    "\"name3\":\"myCookieValue3\","+
-                    "\"name4\":\"myCookieValue4\","+
-                    "\"name5\":\"myCookieValue5\","+
-                    "\"name6\":\"myCookieValue6\""+
-                "}";
         JSONObject jsonObject = CookieList.toJSONObject(cookieStr);
-        JSONObject expectedJsonObject = new JSONObject(expectedCookieStr);
-        String cookieToStr = CookieList.toString(jsonObject);
-        JSONObject finalJsonObject = CookieList.toJSONObject(cookieToStr);
-        Util.compareActualVsExpectedJsonObjects(jsonObject,expectedJsonObject);
-        Util.compareActualVsExpectedJsonObjects(finalJsonObject,expectedJsonObject);
+        Object doc = Configuration.defaultConfiguration().jsonProvider().
+                parse(jsonObject.toString());
+        assertTrue("Expected 6 top level items",
+                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 6);
+        assertTrue("expected myCookieValue1",
+                "myCookieValue1".equals(JsonPath.read(doc, "$.name1")));
+        assertTrue("expected myCookieValue2",
+                "myCookieValue2".equals(JsonPath.read(doc, "$.name2")));
+        assertTrue("expected myCookieValue3",
+                "myCookieValue3".equals(JsonPath.read(doc, "$.name3")));
+        assertTrue("expected myCookieValue4",
+                "myCookieValue4".equals(JsonPath.read(doc, "$.name4")));
+        assertTrue("expected myCookieValue5",
+                "myCookieValue5".equals(JsonPath.read(doc, "$.name5")));
+        assertTrue("expected myCookieValue6",
+                "myCookieValue6".equals(JsonPath.read(doc, "$.name6")));
     }
 
     /**
@@ -169,22 +185,22 @@ public class CookieListTest {
                 "  name4=my%25CookieValue4;  "+
                 "name5=myCookieValue5;"+
                 "  name6=myCookieValue6;";
-            String expectedCookieStr = 
-                "{"+
-                    "\"name1\":\"myCookieValue1\","+
-                    "\"name2\":\"my Cookie Value 2\","+
-                    "\"name3\":\"my+Cookie&Value;3=\","+
-                    "\"name4\":\"my%CookieValue4\","+
-                    "\"name5\":\"myCookieValue5\","+
-                    "\"name6\":\"myCookieValue6\""+
-                "}";
         JSONObject jsonObject = CookieList.toJSONObject(cookieStr);
-        JSONObject expectedJsonObject = new JSONObject(expectedCookieStr);
-        String cookieToStr = CookieList.toString(jsonObject);
-        JSONObject finalJsonObject = CookieList.toJSONObject(cookieToStr);
-        Util.compareActualVsExpectedJsonObjects(jsonObject,expectedJsonObject);
-        Util.compareActualVsExpectedJsonObjects(finalJsonObject,expectedJsonObject);
+        Object doc = Configuration.defaultConfiguration().jsonProvider().
+                parse(jsonObject.toString());
+        assertTrue("Expected 6 top level items",
+                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 6);
+        assertTrue("expected myCookieValue1",
+                "myCookieValue1".equals(JsonPath.read(doc, "$.name1")));
+        assertTrue("expected my Cookie Value 2",
+                "my Cookie Value 2".equals(JsonPath.read(doc, "$.name2")));
+        assertTrue("expected my+Cookie&Value;3=",
+                "my+Cookie&Value;3=".equals(JsonPath.read(doc, "$.name3")));
+        assertTrue("expected my%CookieValue4",
+                "my%CookieValue4".equals(JsonPath.read(doc, "$.name4")));
+        assertTrue("expected my%CookieValue5",
+                "myCookieValue5".equals(JsonPath.read(doc, "$.name5")));
+        assertTrue("expected myCookieValue6",
+                "myCookieValue6".equals(JsonPath.read(doc, "$.name6")));
     }
-    
-
 }

--- a/EnumTest.java
+++ b/EnumTest.java
@@ -35,8 +35,7 @@ public class EnumTest {
         // validate JSON content
         Object doc = Configuration.defaultConfiguration().jsonProvider()
                 .parse(jsonObject.toString());
-        assertTrue("expecting 2 items in top level object",
-                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expecting 2 items in top level object", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
         assertTrue("expecting val 2", "val 2".equals(JsonPath.read(doc, "$.value")));
         assertTrue("expecting 2", Integer.valueOf(2).equals(JsonPath.read(doc, "$.intVal")));
 
@@ -50,14 +49,10 @@ public class EnumTest {
         jsonObject = new JSONObject(myEnumClass);
 
         // validate JSON content
-        doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        assertTrue("expecting 2 items in top level object",
-                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
-        assertTrue("expecting 2 items in myEnumField object",
-                ((Map<?,?>)(JsonPath.read(doc, "$.myEnumField"))).size() == 2);
-        assertTrue("expecting 0 items in myEnum object",
-                ((Map<?,?>)(JsonPath.read(doc, "$.myEnum"))).size() == 0);
+        doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expecting 2 items in top level object", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expecting 2 items in myEnumField object", ((Map<?,?>)(JsonPath.read(doc, "$.myEnumField"))).size() == 2);
+        assertTrue("expecting 0 items in myEnum object", ((Map<?,?>)(JsonPath.read(doc, "$.myEnum"))).size() == 0);
         assertTrue("expecting 3", Integer.valueOf(3).equals(JsonPath.read(doc, "$.myEnumField.intVal")));
         assertTrue("expecting val 3", "val 3".equals(JsonPath.read(doc, "$.myEnumField.value")));
     }

--- a/EnumTest.java
+++ b/EnumTest.java
@@ -2,8 +2,12 @@ package org.json.junit;
 
 import static org.junit.Assert.*;
 
+import java.util.*;
+
 import org.json.*;
 import org.junit.*;
+
+import com.jayway.jsonpath.*;
 
 /**
  * Enums are not explicitly supported in JSON-Java. But because enums act like
@@ -25,23 +29,37 @@ public class EnumTest {
         assertTrue("simple enum has no getters", jsonObject.length() == 0);
 
          // enum with a getters should create a non-empty object 
-        String expectedStr = "{\"value\":\"val 2\", \"intVal\":2}";
         MyEnumField myEnumField = MyEnumField.VAL2;
         jsonObject = new JSONObject(myEnumField);
-        JSONObject expectedJsonObject = new JSONObject(expectedStr);
-        Util.compareActualVsExpectedJsonObjects(jsonObject, expectedJsonObject);
+
+        // validate JSON content
+        Object doc = Configuration.defaultConfiguration().jsonProvider()
+                .parse(jsonObject.toString());
+        assertTrue("expecting 2 items in top level object",
+                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expecting val 2", "val 2".equals(JsonPath.read(doc, "$.value")));
+        assertTrue("expecting 2", Integer.valueOf(2).equals(JsonPath.read(doc, "$.intVal")));
 
         /**
          * class which contains enum instances. Each enum should be stored
          * in its own JSONObject
          */
-        expectedStr = "{\"myEnumField\":{\"intVal\":3,\"value\":\"val 3\"},\"myEnum\":{}}";
         MyEnumClass myEnumClass = new MyEnumClass();
         myEnumClass.setMyEnum(MyEnum.VAL1);
         myEnumClass.setMyEnumField(MyEnumField.VAL3);
         jsonObject = new JSONObject(myEnumClass);
-        expectedJsonObject = new JSONObject(expectedStr);
-        Util.compareActualVsExpectedJsonObjects(jsonObject, expectedJsonObject);
+
+        // validate JSON content
+        doc = Configuration.defaultConfiguration().jsonProvider()
+                .parse(jsonObject.toString());
+        assertTrue("expecting 2 items in top level object",
+                ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expecting 2 items in myEnumField object",
+                ((Map<?,?>)(JsonPath.read(doc, "$.myEnumField"))).size() == 2);
+        assertTrue("expecting 0 items in myEnum object",
+                ((Map<?,?>)(JsonPath.read(doc, "$.myEnum"))).size() == 0);
+        assertTrue("expecting 3", Integer.valueOf(3).equals(JsonPath.read(doc, "$.myEnumField.intVal")));
+        assertTrue("expecting val 3", "val 3".equals(JsonPath.read(doc, "$.myEnumField.value")));
     }
 
     /**
@@ -51,28 +69,30 @@ public class EnumTest {
     @Test
     public void jsonObjectFromEnumWithNames() {
         String [] names;
-        String expectedStr;
         JSONObject jsonObject;
-        JSONObject finalJsonObject;
-        JSONObject expectedJsonObject;
  
-        expectedStr = "{\"VAL1\":\"VAL1\",\"VAL2\":\"VAL2\",\"VAL3\":\"VAL3\"}";
         MyEnum myEnum = MyEnum.VAL1;
         names = JSONObject.getNames(myEnum);
-        // The values will be MyEnmField fields, so need to convert back to string for comparison
+        // The values will be MyEnum fields
         jsonObject = new JSONObject(myEnum, names);
-        finalJsonObject = new JSONObject(jsonObject.toString());
-        expectedJsonObject = new JSONObject(expectedStr);
-        Util.compareActualVsExpectedJsonObjects(finalJsonObject, expectedJsonObject);
 
-        expectedStr = "{\"VAL1\":\"VAL1\",\"VAL2\":\"VAL2\",\"VAL3\":\"VAL3\"}";
+        // validate JSON object
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 3 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 3);
+        assertTrue("expected VAL1", "VAL1".equals(JsonPath.read(doc, "$.VAL1")));
+        assertTrue("expected VAL2", "VAL2".equals(JsonPath.read(doc, "$.VAL2")));
+        assertTrue("expected VAL3", "VAL3".equals(JsonPath.read(doc, "$.VAL3")));
+
         MyEnumField myEnumField = MyEnumField.VAL3;
         names = JSONObject.getNames(myEnumField);
-        // The values will be MyEnmField fields, so need to convert back to string for comparison
+        // The values will be MyEnmField fields
         jsonObject = new JSONObject(myEnumField, names);
-        finalJsonObject = new JSONObject(jsonObject.toString());
-        expectedJsonObject = new JSONObject(expectedStr);
-        Util.compareActualVsExpectedJsonObjects(finalJsonObject, expectedJsonObject);
+        doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 3 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 3);
+        assertTrue("expected VAL1", "VAL1".equals(JsonPath.read(doc, "$.VAL1")));
+        assertTrue("expected VAL2", "VAL2".equals(JsonPath.read(doc, "$.VAL2")));
+        assertTrue("expected VAL3", "VAL3".equals(JsonPath.read(doc, "$.VAL3")));
+
     }
 
     /**
@@ -81,29 +101,33 @@ public class EnumTest {
      */
     @Test
     public void enumPut() {
-        String expectedFinalStr = "{\"myEnum\":\"VAL2\", \"myEnumField\":\"VAL1\"}";
         JSONObject jsonObject = new JSONObject();
         MyEnum myEnum = MyEnum.VAL2;
         jsonObject.put("myEnum", myEnum);
-        assertTrue("expecting myEnum value", MyEnum.VAL2.equals(jsonObject.get("myEnum")));
-        assertTrue("expecting myEnum value", MyEnum.VAL2.equals(jsonObject.opt("myEnum")));
         MyEnumField myEnumField = MyEnumField.VAL1;
         jsonObject.putOnce("myEnumField", myEnumField);
-        assertTrue("expecting myEnumField value", MyEnumField.VAL1.equals(jsonObject.get("myEnumField")));
-        assertTrue("expecting myEnumField value", MyEnumField.VAL1.equals(jsonObject.opt("myEnumField")));
-        JSONObject finalJsonObject = new JSONObject(jsonObject.toString());
-        JSONObject expectedFinalJsonObject = new JSONObject(expectedFinalStr);
-        Util.compareActualVsExpectedJsonObjects(finalJsonObject, expectedFinalJsonObject);
 
+        // validate JSON content
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 2 top level objects", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expected VAL2", "VAL2".equals(JsonPath.read(doc, "$.myEnum")));
+        assertTrue("expected VAL1", "VAL1".equals(JsonPath.read(doc, "$.myEnumField")));
+        
         JSONArray jsonArray = new JSONArray();
         jsonArray.put(myEnum);
         jsonArray.put(1, myEnumField);
+
+        // validate JSON content
+        doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonArray.toString());
+        assertTrue("expected 2 top level objects", ((List<?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expected VAL2", "VAL2".equals(JsonPath.read(doc, "$[0]")));
+        assertTrue("expected VAL1", "VAL1".equals(JsonPath.read(doc, "$[1]")));
+
+        /**
+         * Leaving these tests because they exercise get, opt, and remove
+         */
         assertTrue("expecting myEnum value", MyEnum.VAL2.equals(jsonArray.get(0)));
         assertTrue("expecting myEnumField value", MyEnumField.VAL1.equals(jsonArray.opt(1)));
-        JSONArray expectedJsonArray = new JSONArray();
-        expectedJsonArray.put(MyEnum.VAL2);
-        expectedJsonArray.put(MyEnumField.VAL1);
-        Util.compareActualVsExpectedJsonArrays(jsonArray, expectedJsonArray);
         assertTrue("expecting myEnumField value", MyEnumField.VAL1.equals(jsonArray.remove(1)));
     }
 
@@ -151,49 +175,66 @@ public class EnumTest {
 
         MyEnumField myEnumField = MyEnumField.VAL2;
         jsonObject = new JSONObject(myEnumField);
-        expectedStr = "{\"value\":\"val 2\", \"intVal\":2}";
-        JSONObject actualJsonObject = new JSONObject(jsonObject.toString());
-        JSONObject expectedJsonObject = new JSONObject(expectedStr);
-        Util.compareActualVsExpectedJsonObjects(actualJsonObject, expectedJsonObject);
 
-        expectedStr = "{\"myEnumField\":{\"intVal\":3,\"value\":\"val 3\"},\"myEnum\":{}}";
+        // validate JSON content
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 2 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expected val 2", "val 2".equals(JsonPath.read(doc, "$.value")));
+        assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc, "$.intVal")));
+
         MyEnumClass myEnumClass = new MyEnumClass();
         myEnumClass.setMyEnum(MyEnum.VAL1);
         myEnumClass.setMyEnumField(MyEnumField.VAL3);
         jsonObject = new JSONObject(myEnumClass);
-        actualJsonObject = new JSONObject(jsonObject.toString());
-        expectedJsonObject = new JSONObject(expectedStr);
-        Util.compareActualVsExpectedJsonObjects(actualJsonObject, expectedJsonObject);
 
-        expectedStr = "{\"VAL1\":\"VAL1\",\"VAL2\":\"VAL2\",\"VAL3\":\"VAL3\"}";
+        // validate JSON content
+        doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 2 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expected 2 myEnumField items", ((Map<?,?>)(JsonPath.read(doc, "$.myEnumField"))).size() == 2);
+        assertTrue("expected 0 myEnum items", ((Map<?,?>)(JsonPath.read(doc, "$.myEnum"))).size() == 0);
+        assertTrue("expected 3", Integer.valueOf(3).equals(JsonPath.read(doc, "$.myEnumField.intVal")));
+        assertTrue("expected val 3", "val 3".equals(JsonPath.read(doc, "$.myEnumField.value")));
+
         String [] names = JSONObject.getNames(myEnum);
         jsonObject = new JSONObject(myEnum, names);
-        actualJsonObject = new JSONObject(jsonObject.toString());
-        expectedJsonObject = new JSONObject(expectedStr);
-        Util.compareActualVsExpectedJsonObjects(actualJsonObject, expectedJsonObject);
 
-        expectedStr = "{\"VAL1\":\"VAL1\",\"VAL2\":\"VAL2\",\"VAL3\":\"VAL3\"}";
+        // validate JSON content
+        doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 3 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 3);
+        assertTrue("expected VAL1", "VAL1".equals(JsonPath.read(doc, "$.VAL1")));
+        assertTrue("expected VAL2", "VAL2".equals(JsonPath.read(doc, "$.VAL2")));
+        assertTrue("expected VAL3", "VAL3".equals(JsonPath.read(doc, "$.VAL3")));
+        
         names = JSONObject.getNames(myEnumField);
         jsonObject = new JSONObject(myEnumField, names);
-        actualJsonObject = new JSONObject(jsonObject.toString());
-        expectedJsonObject = new JSONObject(expectedStr);
-        Util.compareActualVsExpectedJsonObjects(actualJsonObject, expectedJsonObject);
+
+        // validate JSON content
+        doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 3 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 3);
+        assertTrue("expected VAL1", "VAL1".equals(JsonPath.read(doc, "$.VAL1")));
+        assertTrue("expected VAL2", "VAL2".equals(JsonPath.read(doc, "$.VAL2")));
+        assertTrue("expected VAL3", "VAL3".equals(JsonPath.read(doc, "$.VAL3")));
 
         expectedStr = "{\"myEnum\":\"VAL2\", \"myEnumField\":\"VAL2\"}";
         jsonObject = new JSONObject();
         jsonObject.putOpt("myEnum", myEnum);
         jsonObject.putOnce("myEnumField", myEnumField);
-        actualJsonObject = new JSONObject(jsonObject.toString());
-        expectedJsonObject = new JSONObject(expectedStr);
-        Util.compareActualVsExpectedJsonObjects(actualJsonObject, expectedJsonObject);
 
-        expectedStr = "[\"VAL2\", \"VAL2\"]";
+        // validate JSON content
+        doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 2 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expected VAL2", "VAL2".equals(JsonPath.read(doc, "$.myEnum")));
+        assertTrue("expected VAL2", "VAL2".equals(JsonPath.read(doc, "$.myEnumField")));
+
         JSONArray jsonArray = new JSONArray();
         jsonArray.put(myEnum);
         jsonArray.put(1, myEnumField);
-        JSONArray actualJsonArray = new JSONArray(jsonArray.toString());
-        JSONArray expectedJsonArray = new JSONArray(expectedStr);
-        Util.compareActualVsExpectedJsonArrays(actualJsonArray, expectedJsonArray);
+
+        // validate JSON content
+        doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonArray.toString());
+        assertTrue("expected 2 top level items", ((List<?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expected VAL2", "VAL2".equals(JsonPath.read(doc, "$[0]")));
+        assertTrue("expected VAL2", "VAL2".equals(JsonPath.read(doc, "$[1]")));
     }
 
     /**
@@ -206,19 +247,28 @@ public class EnumTest {
         JSONObject jsonObject = (JSONObject)JSONObject.wrap(myEnum);
         assertTrue("simple enum has no getters", jsonObject.length() == 0);
 
-        String expectedStr = "{\"value\":\"val 2\", \"intVal\":2}";
         MyEnumField myEnumField = MyEnumField.VAL2;
         jsonObject = (JSONObject)JSONObject.wrap(myEnumField);
-        JSONObject expectedJsonObject = new JSONObject(expectedStr);
-        Util.compareActualVsExpectedJsonObjects(jsonObject, expectedJsonObject);
 
-        expectedStr = "{\"myEnumField\":{\"intVal\":3,\"value\":\"val 3\"},\"myEnum\":{}}";
+        // validate JSON content
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 2 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expected val 2", "val 2".equals(JsonPath.read(doc, "$.value")));
+        assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc, "$.intVal")));
+
         MyEnumClass myEnumClass = new MyEnumClass();
         myEnumClass.setMyEnum(MyEnum.VAL1);
         myEnumClass.setMyEnumField(MyEnumField.VAL3);
         jsonObject = (JSONObject)JSONObject.wrap(myEnumClass);
-        expectedJsonObject = new JSONObject(expectedStr);
-        Util.compareActualVsExpectedJsonObjects(jsonObject, expectedJsonObject);
+
+        // validate JSON content
+        doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 2 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expected 2 myEnumField items", ((Map<?,?>)(JsonPath.read(doc, "$.myEnumField"))).size() == 2);
+        assertTrue("expected 0 myEnum items", ((Map<?,?>)(JsonPath.read(doc, "$.myEnum"))).size() == 0);
+        assertTrue("expected 3", Integer.valueOf(3).equals(JsonPath.read(doc, "$.myEnumField.intVal")));
+        assertTrue("expected val 3", "val 3".equals(JsonPath.read(doc, "$.myEnumField.value")));
+
     }
 
     /**

--- a/JSONArrayTest.java
+++ b/JSONArrayTest.java
@@ -314,10 +314,8 @@ public class JSONArrayTest {
         /**
          * Don't need to remake the JSONArray to perform the parsing
          */
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse("["+joinStr+"]");
-        List<?> docList = JsonPath.read(doc, "$");
-        assertTrue("expected 13 items in top level object", docList.size() == 13);
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse("["+joinStr+"]");
+        assertTrue("expected 13 items in top level object", ((List<?>)(JsonPath.read(doc, "$"))).size() == 13);
         assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc,  "$[0]")));
         assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc,  "$[1]")));
         assertTrue("expected \"true\"", "true".equals(JsonPath.read(doc,  "$[2]")));
@@ -327,11 +325,9 @@ public class JSONArrayTest {
         assertTrue("expected \"23.45\"", "23.45".equals(JsonPath.read(doc,  "$[6]")));
         assertTrue("expected 42", Integer.valueOf(42).equals(JsonPath.read(doc,  "$[7]")));
         assertTrue("expected \"43\"", "43".equals(JsonPath.read(doc,  "$[8]")));
-        docList = JsonPath.read(doc, "$[9]");
-        assertTrue("expected 1 array item", docList.size() == 1);
+        assertTrue("expected 1 item in [9]", ((List<?>)(JsonPath.read(doc, "$[9]"))).size() == 1);
         assertTrue("expected world", "world".equals(JsonPath.read(doc,  "$[9][0]")));
-        Map<?,?> docMap = JsonPath.read(doc, "$[10]");
-        assertTrue("expected 4 object items", docMap.size() == 4);
+        assertTrue("expected 4 items in [10]", ((Map<?,?>)(JsonPath.read(doc, "$[10]"))).size() == 4);
         assertTrue("expected value1", "value1".equals(JsonPath.read(doc,  "$[10].key1")));
         assertTrue("expected value2", "value2".equals(JsonPath.read(doc,  "$[10].key2")));
         assertTrue("expected value3", "value3".equals(JsonPath.read(doc,  "$[10].key3")));
@@ -463,30 +459,24 @@ public class JSONArrayTest {
         jsonArray.put(collection);
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonArray.toString());
-        List<?> docList = JsonPath.read(doc, "$");
-        assertTrue("expected 10 items in top level object", docList.size() == 10);
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonArray.toString());
+        assertTrue("expected 10 top level items", ((List<?>)(JsonPath.read(doc, "$"))).size() == 10);
         assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc,  "$[0]")));
         assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc,  "$[1]")));
-        docList = JsonPath.read(doc,  "$[2]");
-        assertTrue("expected 2 items in array", docList.size() == 2);
+        assertTrue("expected 2 items in [2]", ((List<?>)(JsonPath.read(doc, "$[2]"))).size() == 2);
         assertTrue("expected hello", "hello".equals(JsonPath.read(doc,  "$[2][0]")));
         assertTrue("expected world", "world".equals(JsonPath.read(doc,  "$[2][1]")));
         assertTrue("expected 2.5", Double.valueOf(2.5).equals(JsonPath.read(doc,  "$[3]")));
         assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc,  "$[4]")));
         assertTrue("expected 45", Integer.valueOf(45).equals(JsonPath.read(doc,  "$[5]")));
         assertTrue("expected objectPut", "objectPut".equals(JsonPath.read(doc,  "$[6]")));
-        Map<?,?> docMap = JsonPath.read(doc, "$[7]");
-        assertTrue("expected 3 items in object", docMap.size() == 3);
+        assertTrue("expected 3 items in [7]", ((Map<?,?>)(JsonPath.read(doc, "$[7]"))).size() == 3);
         assertTrue("expected val10", "val10".equals(JsonPath.read(doc, "$[7].key10")));
         assertTrue("expected val20", "val20".equals(JsonPath.read(doc, "$[7].key20")));
         assertTrue("expected val30", "val30".equals(JsonPath.read(doc, "$[7].key30")));
-        docMap = JsonPath.read(doc, "$[8]");
-        assertTrue("expected 1 item in object", docMap.size() == 1);
+        assertTrue("expected 1 item in [8]", ((Map<?,?>)(JsonPath.read(doc, "$[8]"))).size() == 1);
         assertTrue("expected v1", "v1".equals(JsonPath.read(doc, "$[8].k1")));
-        docList = JsonPath.read(doc,  "$[9]");
-        assertTrue("expected 2 items in array", docList.size() == 2);
+        assertTrue("expected 2 items in [9]", ((List<?>)(JsonPath.read(doc, "$[9]"))).size() == 2);
         assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc,  "$[9][0]")));
         assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc,  "$[9][1]")));
     }
@@ -546,14 +536,11 @@ public class JSONArrayTest {
         } catch(Exception ignored) {}
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonArray.toString());
-        List<?> docList = JsonPath.read(doc, "$");
-        assertTrue("expected 11 items in top level object", docList.size() == 11);
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonArray.toString());
+        assertTrue("expected 11 top level items", ((List<?>)(JsonPath.read(doc, "$"))).size() == 11);
         assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc,  "$[0]")));
         assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc,  "$[1]")));
-        docList = JsonPath.read(doc,  "$[2]");
-        assertTrue("expected 2 items in array", docList.size() == 2);
+        assertTrue("expected 2 items in [2]", ((List<?>)(JsonPath.read(doc, "$[2]"))).size() == 2);
         assertTrue("expected hello", "hello".equals(JsonPath.read(doc,  "$[2][0]")));
         assertTrue("expected world", "world".equals(JsonPath.read(doc,  "$[2][1]")));
         assertTrue("expected 2.5", Double.valueOf(2.5).equals(JsonPath.read(doc,  "$[3]")));
@@ -561,17 +548,14 @@ public class JSONArrayTest {
         assertTrue("expected 45", Integer.valueOf(45).equals(JsonPath.read(doc,  "$[5]")));
         assertTrue("expected objectPut", "objectPut".equals(JsonPath.read(doc,  "$[6]")));
         assertTrue("expected null", null == JsonPath.read(doc,  "$[7]"));
-        Map<?,?> docMap = JsonPath.read(doc, "$[8]");
-        assertTrue("expected 3 items in object", docMap.size() == 3);
+        assertTrue("expected 3 items in [8]", ((Map<?,?>)(JsonPath.read(doc, "$[8]"))).size() == 3);
         assertTrue("expected val10", "val10".equals(JsonPath.read(doc, "$[8].key10")));
         assertTrue("expected val20", "val20".equals(JsonPath.read(doc, "$[8].key20")));
         assertTrue("expected val30", "val30".equals(JsonPath.read(doc, "$[8].key30")));
-        docList = JsonPath.read(doc,  "$[9]");
-        assertTrue("expected 2 items in array", docList.size() == 2);
+        assertTrue("expected 2 items in [9]", ((List<?>)(JsonPath.read(doc, "$[9]"))).size() == 2);
         assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc,  "$[9][0]")));
         assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc,  "$[9][1]")));
-        docMap = JsonPath.read(doc, "$[10]");
-        assertTrue("expected 1 item in object", docMap.size() == 1);
+        assertTrue("expected 1 item in [10]", ((Map<?,?>)(JsonPath.read(doc, "$[10]"))).size() == 1);
         assertTrue("expected v1", "v1".equals(JsonPath.read(doc, "$[10].k1")));
     }
 
@@ -651,10 +635,8 @@ public class JSONArrayTest {
         JSONArray jsonArray = new JSONArray(myObject);
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonArray.toString());
-        List<?> docList = JsonPath.read(doc, "$");
-        assertTrue("expected 7 items in top level object", docList.size() == 7);
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonArray.toString());
+        assertTrue("expected 7 top level items", ((List<?>)(JsonPath.read(doc, "$"))).size() == 7);
         assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc,  "$[0]")));
         assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc,  "$[1]")));
         assertTrue("expected 3", Integer.valueOf(3).equals(JsonPath.read(doc,  "$[2]")));

--- a/JSONArrayTest.java
+++ b/JSONArrayTest.java
@@ -2,17 +2,14 @@ package org.json.junit;
 
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
+
+import com.jayway.jsonpath.*;
 
 
 /**
@@ -306,41 +303,41 @@ public class JSONArrayTest {
     /**
      * Exercise JSONArray.join() by converting a JSONArray into a 
      * comma-separated string. Since this is very nearly a JSON document,
-     * array braces are added to the beginning and end, and it is reconverted
-     * back to a JSONArray for comparison.
+     * array braces are added to the beginning and end prior to validation.
      */
     @Test
     public void join() {
-        String expectedStr =
-            "["+
-                "true,"+
-                "false,"+
-                "\"true\","+
-                "\"false\","+
-                "\"hello\","+
-                "0.002345,"+
-                "\"23.45\","+
-                "42,"+
-                "\"43\","+
-                "["+
-                    "\"world\""+
-                "],"+
-                "{"+
-                    "\"key1\":\"value1\","+
-                    "\"key2\":\"value2\","+
-                    "\"key3\":\"value3\","+
-                    "\"key4\":\"value4\""+
-                "},"+
-                "0,"+
-                "\"-1\""+
-            "]";
-
         JSONArray jsonArray = new JSONArray(arrayStr);
         String joinStr = jsonArray.join(",");
-        JSONArray finalJsonArray = new JSONArray("["+joinStr+"]");
-        JSONArray expectedJsonArray = new JSONArray(expectedStr);
-        Util.compareActualVsExpectedJsonArrays(jsonArray, expectedJsonArray);
-        Util.compareActualVsExpectedJsonArrays(finalJsonArray, expectedJsonArray);
+
+        // validate JSON
+        /**
+         * Don't need to remake the JSONArray to perform the parsing
+         */
+        Object doc = Configuration.defaultConfiguration().jsonProvider()
+                .parse("["+joinStr+"]");
+        List<?> docList = JsonPath.read(doc, "$");
+        assertTrue("expected 13 items in top level object", docList.size() == 13);
+        assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc,  "$[0]")));
+        assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc,  "$[1]")));
+        assertTrue("expected \"true\"", "true".equals(JsonPath.read(doc,  "$[2]")));
+        assertTrue("expected \"false\"", "false".equals(JsonPath.read(doc,  "$[3]")));
+        assertTrue("expected hello", "hello".equals(JsonPath.read(doc,  "$[4]")));
+        assertTrue("expected 0.002345", Double.valueOf(0.002345).equals(JsonPath.read(doc,  "$[5]")));
+        assertTrue("expected \"23.45\"", "23.45".equals(JsonPath.read(doc,  "$[6]")));
+        assertTrue("expected 42", Integer.valueOf(42).equals(JsonPath.read(doc,  "$[7]")));
+        assertTrue("expected \"43\"", "43".equals(JsonPath.read(doc,  "$[8]")));
+        docList = JsonPath.read(doc, "$[9]");
+        assertTrue("expected 1 array item", docList.size() == 1);
+        assertTrue("expected world", "world".equals(JsonPath.read(doc,  "$[9][0]")));
+        Map<?,?> docMap = JsonPath.read(doc, "$[10]");
+        assertTrue("expected 4 object items", docMap.size() == 4);
+        assertTrue("expected value1", "value1".equals(JsonPath.read(doc,  "$[10].key1")));
+        assertTrue("expected value2", "value2".equals(JsonPath.read(doc,  "$[10].key2")));
+        assertTrue("expected value3", "value3".equals(JsonPath.read(doc,  "$[10].key3")));
+        assertTrue("expected value4", "value4".equals(JsonPath.read(doc,  "$[10].key4")));
+        assertTrue("expected 0", Integer.valueOf(0).equals(JsonPath.read(doc,  "$[11]")));
+        assertTrue("expected \"-1\"", "-1".equals(JsonPath.read(doc,  "$[12]")));
     }
 
     /**
@@ -419,33 +416,7 @@ public class JSONArrayTest {
      */
     @Test
     public void put() {
-        String expectedStr =
-            "["+
-                "true,"+
-                "false,"+
-                "["+
-                    "hello,"+
-                    "world"+
-                "],"+
-                "2.5,"+
-                "1,"+
-                "45,"+
-                "\"objectPut\","+
-                "{"+
-                    "\"key10\":\"val10\","+
-                    "\"key20\":\"val20\","+
-                    "\"key30\":\"val30\""+
-                "},"+
-                "{"+
-                    "\"k1\":\"v1\""+
-                "},"+
-                "["+
-                    "1,"+
-                    "2"+
-                "]"+
-            "]";
         JSONArray jsonArray = new JSONArray();
-        JSONArray expectedJsonArray = new JSONArray(expectedStr);
 
         // index 0
         jsonArray.put(true);
@@ -488,9 +459,36 @@ public class JSONArrayTest {
         Collection<Object> collection = new ArrayList<Object>();
         collection.add(1);
         collection.add(2);
-            // 9
+        // 9
         jsonArray.put(collection);
-        Util.compareActualVsExpectedJsonArrays(jsonArray, expectedJsonArray);
+
+        // validate JSON
+        Object doc = Configuration.defaultConfiguration().jsonProvider()
+                .parse(jsonArray.toString());
+        List<?> docList = JsonPath.read(doc, "$");
+        assertTrue("expected 10 items in top level object", docList.size() == 10);
+        assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc,  "$[0]")));
+        assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc,  "$[1]")));
+        docList = JsonPath.read(doc,  "$[2]");
+        assertTrue("expected 2 items in array", docList.size() == 2);
+        assertTrue("expected hello", "hello".equals(JsonPath.read(doc,  "$[2][0]")));
+        assertTrue("expected world", "world".equals(JsonPath.read(doc,  "$[2][1]")));
+        assertTrue("expected 2.5", Double.valueOf(2.5).equals(JsonPath.read(doc,  "$[3]")));
+        assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc,  "$[4]")));
+        assertTrue("expected 45", Integer.valueOf(45).equals(JsonPath.read(doc,  "$[5]")));
+        assertTrue("expected objectPut", "objectPut".equals(JsonPath.read(doc,  "$[6]")));
+        Map<?,?> docMap = JsonPath.read(doc, "$[7]");
+        assertTrue("expected 3 items in object", docMap.size() == 3);
+        assertTrue("expected val10", "val10".equals(JsonPath.read(doc, "$[7].key10")));
+        assertTrue("expected val20", "val20".equals(JsonPath.read(doc, "$[7].key20")));
+        assertTrue("expected val30", "val30".equals(JsonPath.read(doc, "$[7].key30")));
+        docMap = JsonPath.read(doc, "$[8]");
+        assertTrue("expected 1 item in object", docMap.size() == 1);
+        assertTrue("expected v1", "v1".equals(JsonPath.read(doc, "$[8].k1")));
+        docList = JsonPath.read(doc,  "$[9]");
+        assertTrue("expected 2 items in array", docList.size() == 2);
+        assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc,  "$[9][0]")));
+        assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc,  "$[9][1]")));
     }
 
     /**
@@ -499,34 +497,7 @@ public class JSONArrayTest {
      */
     @Test
     public void putIndex() {
-        String expectedStr =
-            "["+
-                "true,"+
-                "false,"+
-                "["+
-                    "hello,"+
-                    "world"+
-                "],"+
-                "2.5,"+
-                "1,"+
-                "45,"+
-                "\"objectPut\","+
-                "null,"+
-                "{"+
-                    "\"key10\":\"val10\","+
-                    "\"key20\":\"val20\","+
-                    "\"key30\":\"val30\""+
-                "},"+
-                "["+
-                    "1,"+
-                    "2"+
-                "],"+
-                "{"+
-                    "\"k1\":\"v1\""+
-                "},"+
-            "]";
         JSONArray jsonArray = new JSONArray();
-        JSONArray expectedJsonArray = new JSONArray(expectedStr);
 
         // 1
         jsonArray.put(1, false);
@@ -573,7 +544,35 @@ public class JSONArrayTest {
             jsonArray.put(-1, "abc");
             assertTrue("put index < 0 should have thrown exception", false);
         } catch(Exception ignored) {}
-        Util.compareActualVsExpectedJsonArrays(jsonArray, expectedJsonArray);
+
+        // validate JSON
+        Object doc = Configuration.defaultConfiguration().jsonProvider()
+                .parse(jsonArray.toString());
+        List<?> docList = JsonPath.read(doc, "$");
+        assertTrue("expected 11 items in top level object", docList.size() == 11);
+        assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc,  "$[0]")));
+        assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc,  "$[1]")));
+        docList = JsonPath.read(doc,  "$[2]");
+        assertTrue("expected 2 items in array", docList.size() == 2);
+        assertTrue("expected hello", "hello".equals(JsonPath.read(doc,  "$[2][0]")));
+        assertTrue("expected world", "world".equals(JsonPath.read(doc,  "$[2][1]")));
+        assertTrue("expected 2.5", Double.valueOf(2.5).equals(JsonPath.read(doc,  "$[3]")));
+        assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc,  "$[4]")));
+        assertTrue("expected 45", Integer.valueOf(45).equals(JsonPath.read(doc,  "$[5]")));
+        assertTrue("expected objectPut", "objectPut".equals(JsonPath.read(doc,  "$[6]")));
+        assertTrue("expected null", null == JsonPath.read(doc,  "$[7]"));
+        Map<?,?> docMap = JsonPath.read(doc, "$[8]");
+        assertTrue("expected 3 items in object", docMap.size() == 3);
+        assertTrue("expected val10", "val10".equals(JsonPath.read(doc, "$[8].key10")));
+        assertTrue("expected val20", "val20".equals(JsonPath.read(doc, "$[8].key20")));
+        assertTrue("expected val30", "val30".equals(JsonPath.read(doc, "$[8].key30")));
+        docList = JsonPath.read(doc,  "$[9]");
+        assertTrue("expected 2 items in array", docList.size() == 2);
+        assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc,  "$[9][0]")));
+        assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc,  "$[9][1]")));
+        docMap = JsonPath.read(doc, "$[10]");
+        assertTrue("expected 1 item in object", docMap.size() == 1);
+        assertTrue("expected v1", "v1".equals(JsonPath.read(doc, "$[10].k1")));
     }
 
     /**
@@ -587,10 +586,9 @@ public class JSONArrayTest {
                 "1"+
             "]";
         JSONArray jsonArray = new JSONArray(arrayStr);
-        JSONArray expectedJsonArray = new JSONArray();
         jsonArray.remove(0);
         assertTrue("array should be empty", null == jsonArray.remove(5));
-        Util.compareActualVsExpectedJsonArrays(jsonArray, expectedJsonArray);
+        assertTrue("jsonArray should be empty", jsonArray.length() == 0);
     }
 
     /**
@@ -648,15 +646,22 @@ public class JSONArrayTest {
      */
     @Test
     public void objectArrayVsIsArray() {
-        String expectedStr = 
-            "["+
-                "1,2,3,4,5,6,7"+
-            "]";
         int[] myInts = { 1, 2, 3, 4, 5, 6, 7 };
         Object myObject = myInts;
         JSONArray jsonArray = new JSONArray(myObject);
-        JSONArray expectedJsonArray = new JSONArray(expectedStr);
-        Util.compareActualVsExpectedJsonArrays(jsonArray, expectedJsonArray);
+
+        // validate JSON
+        Object doc = Configuration.defaultConfiguration().jsonProvider()
+                .parse(jsonArray.toString());
+        List<?> docList = JsonPath.read(doc, "$");
+        assertTrue("expected 7 items in top level object", docList.size() == 7);
+        assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc,  "$[0]")));
+        assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc,  "$[1]")));
+        assertTrue("expected 3", Integer.valueOf(3).equals(JsonPath.read(doc,  "$[2]")));
+        assertTrue("expected 4", Integer.valueOf(4).equals(JsonPath.read(doc,  "$[3]")));
+        assertTrue("expected 5", Integer.valueOf(5).equals(JsonPath.read(doc,  "$[4]")));
+        assertTrue("expected 6", Integer.valueOf(6).equals(JsonPath.read(doc,  "$[5]")));
+        assertTrue("expected 7", Integer.valueOf(7).equals(JsonPath.read(doc,  "$[6]")));
     }
 
     /**

--- a/JSONObjectTest.java
+++ b/JSONObjectTest.java
@@ -110,20 +110,12 @@ public class JSONObjectTest {
 
         // validate JSON
         JSONObject jsonObjectByName = new JSONObject(jsonObject, keys);
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObjectByName.toString());
-        Map<String, Map<?, ?>> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 4 items", docMap.size() == 4);
-        assertTrue("expected \"falseKey\":false",
-                Boolean.FALSE.equals(JsonPath.read(doc, "$.falseKey")));
-        assertTrue("expected \"nullKey\":null",
-                null == JsonPath.read(doc, "$.nullKey"));
-        assertTrue("expected \"stringKey\":\"hello world!\"",
-                "hello world!".equals(JsonPath.read(doc, "$.stringKey")));
-        assertTrue(
-                "expected \"doubleKey\":-23.45e67",
-                Double.valueOf("-23.45e67").equals(
-                        JsonPath.read(doc, "$.doubleKey")));
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObjectByName.toString());
+        assertTrue("expected 4 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 4);
+        assertTrue("expected \"falseKey\":false", Boolean.FALSE.equals(JsonPath.read(doc, "$.falseKey")));
+        assertTrue("expected \"nullKey\":null", null == JsonPath.read(doc, "$.nullKey"));
+        assertTrue("expected \"stringKey\":\"hello world!\"", "hello world!".equals(JsonPath.read(doc, "$.stringKey")));
+        assertTrue("expected \"doubleKey\":-23.45e67", Double.valueOf("-23.45e67").equals(JsonPath.read(doc, "$.doubleKey")));
     }
 
     /**
@@ -155,23 +147,13 @@ public class JSONObjectTest {
         JSONObject jsonObject = new JSONObject(map);
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 6 items", docMap.size() == 6);
-        assertTrue("expected \"trueKey\":true",
-                Boolean.TRUE.equals(JsonPath.read(doc, "$.trueKey")));
-        assertTrue("expected \"falseKey\":false",
-                Boolean.FALSE.equals(JsonPath.read(doc, "$.falseKey")));
-        assertTrue("expected \"stringKey\":\"hello world!\"",
-                "hello world!".equals(JsonPath.read(doc, "$.stringKey")));
-        assertTrue("expected \"escapeStringKey\":\"h\be\tllo w\u1234orld!\"",
-                "h\be\tllo w\u1234orld!".equals(JsonPath.read(doc,
-                        "$.escapeStringKey")));
-        assertTrue(
-                "expected \"doubleKey\":-23.45e67",
-                Double.valueOf("-23.45e67").equals(
-                        JsonPath.read(doc, "$.doubleKey")));
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 6 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 6);
+        assertTrue("expected \"trueKey\":true", Boolean.TRUE.equals(JsonPath.read(doc, "$.trueKey")));
+        assertTrue("expected \"falseKey\":false", Boolean.FALSE.equals(JsonPath.read(doc, "$.falseKey")));
+        assertTrue("expected \"stringKey\":\"hello world!\"", "hello world!".equals(JsonPath.read(doc, "$.stringKey")));
+        assertTrue("expected \"escapeStringKey\":\"h\be\tllo w\u1234orld!\"", "h\be\tllo w\u1234orld!".equals(JsonPath.read(doc,"$.escapeStringKey")));
+        assertTrue("expected \"doubleKey\":-23.45e67", Double.valueOf("-23.45e67").equals(JsonPath.read(doc, "$.doubleKey")));
     }
     
     /**
@@ -305,14 +287,10 @@ public class JSONObjectTest {
         JSONObject jsonObject = new JSONObject(jsonMap);
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 2 items", docMap.size() == 2);
-        assertTrue("expected \"key2\":java.lang.Exception",
-                "java.lang.Exception".equals(JsonPath.read(doc, "$.key2")));
-        docMap = JsonPath.read(doc, "$.key1");
-        assertTrue("expected 0 items", docMap.size() == 0);
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 2 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expected \"key2\":java.lang.Exception","java.lang.Exception".equals(JsonPath.read(doc, "$.key2")));
+        assertTrue("expected 0 key1 items", ((Map<?,?>)(JsonPath.read(doc, "$.key1"))).size() == 0);
     }
 
     /**
@@ -332,25 +310,14 @@ public class JSONObjectTest {
         JSONObject jsonObject = new JSONObject(map);
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 6 items", docMap.size() == 6);
-        assertTrue("expected \"trueKey\":true",
-                Boolean.TRUE.equals(JsonPath.read(doc, "$.trueKey")));
-        assertTrue("expected \"falseKey\":false",
-                Boolean.FALSE.equals(JsonPath.read(doc, "$.falseKey")));
-        assertTrue("expected \"stringKey\":\"hello world!\"",
-                "hello world!".equals(JsonPath.read(doc, "$.stringKey")));
-        assertTrue("expected \"escapeStringKey\":\"h\be\tllo w\u1234orld!\"",
-                "h\be\tllo w\u1234orld!".equals(JsonPath.read(doc,
-                        "$.escapeStringKey")));
-        assertTrue("expected \"intKey\":42",
-                Integer.valueOf("42").equals(JsonPath.read(doc, "$.intKey")));
-        assertTrue(
-                "expected \"doubleKey\":-23.45e67",
-                Double.valueOf("-23.45e67").equals(
-                        JsonPath.read(doc, "$.doubleKey")));
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 6 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 6);
+        assertTrue("expected \"trueKey\":true", Boolean.TRUE.equals(JsonPath.read(doc, "$.trueKey")));
+        assertTrue("expected \"falseKey\":false", Boolean.FALSE.equals(JsonPath.read(doc, "$.falseKey")));
+        assertTrue("expected \"stringKey\":\"hello world!\"", "hello world!".equals(JsonPath.read(doc, "$.stringKey")));
+        assertTrue("expected \"escapeStringKey\":\"h\be\tllo w\u1234orld!\"", "h\be\tllo w\u1234orld!".equals(JsonPath.read(doc,"$.escapeStringKey")));
+        assertTrue("expected \"intKey\":42", Integer.valueOf("42").equals(JsonPath.read(doc, "$.intKey")));
+        assertTrue("expected \"doubleKey\":-23.45e67", Double.valueOf("-23.45e67").equals(JsonPath.read(doc, "$.doubleKey")));
     }
 
     /**
@@ -386,35 +353,19 @@ public class JSONObjectTest {
         JSONObject jsonObject = new JSONObject(myBean);
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 8 items", docMap.size() == 8);
-        assertTrue("expected \"trueKey\":true",
-                Boolean.TRUE.equals(JsonPath.read(doc, "$.trueKey")));
-        assertTrue("expected \"falseKey\":false",
-                Boolean.FALSE.equals(JsonPath.read(doc, "$.falseKey")));
-        assertTrue("expected \"stringKey\":\"hello world!\"",
-                "hello world!".equals(JsonPath.read(doc, "$.stringKey")));
-        assertTrue("expected \"escapeStringKey\":\"h\be\tllo w\u1234orld!\"",
-                "h\be\tllo w\u1234orld!".equals(JsonPath.read(doc,
-                        "$.escapeStringKey")));
-        assertTrue("expected \"intKey\":42",
-                Integer.valueOf("42").equals(JsonPath.read(doc, "$.intKey")));
-        assertTrue("expected \"doubleKey\":-23.45e7", Double
-                .valueOf("-23.45e7").equals(JsonPath.read(doc, "$.doubleKey")));
-        assertTrue(
-                "expected \"stringReaderKey\":{}",
-                ((Map<?, ?>) (JsonPath.read(doc, "$.stringReaderKey"))).size() == 0);
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 8 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 8);
+        assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc, "$.trueKey")));
+        assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc, "$.falseKey")));
+        assertTrue("expected hello world!","hello world!".equals(JsonPath.read(doc, "$.stringKey")));
+        assertTrue("expected h\be\tllo w\u1234orld!", "h\be\tllo w\u1234orld!".equals(JsonPath.read(doc,"$.escapeStringKey")));
+        assertTrue("expected 42", Integer.valueOf("42").equals(JsonPath.read(doc, "$.intKey")));
+        assertTrue("expected -23.45e7", Double.valueOf("-23.45e7").equals(JsonPath.read(doc, "$.doubleKey")));
+        assertTrue("expected 0 items in stringReaderKey", ((Map<?, ?>) (JsonPath.read(doc, "$.stringReaderKey"))).size() == 0);
         // sorry, mockito artifact
-        List<?> docList = JsonPath.read(doc, "$.callbacks");
-        assertTrue("expected 2 items", docList.size() == 2);
-        assertTrue("expected \"handler\":{}",
-                ((Map<?, ?>) (JsonPath.read(doc,
-                        "$.callbacks[0].handler"))).size() == 0);
-        assertTrue("expected empty object",
-                ((Map<?, ?>) (JsonPath.read(doc, "$.callbacks[1]")))
-                        .size() == 0);
+        assertTrue("expected 2 callbacks items", ((List<?>)(JsonPath.read(doc, "$.callbacks"))).size() == 2);
+        assertTrue("expected 0 handler items", ((Map<?,?>)(JsonPath.read(doc, "$.callbacks[0].handler"))).size() == 0);
+        assertTrue("expected 0 callbacks[1] items", ((Map<?,?>)(JsonPath.read(doc, "$.callbacks[1]"))).size() == 0);
     }
 
     /**
@@ -431,14 +382,10 @@ public class JSONObjectTest {
         JSONObject jsonObject = new JSONObject(jsonObjectTest, keys);
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 2 items", docMap.size() == 2);
-        assertTrue("expected \"publicString\":\"abc\"",
-                "abc".equals(JsonPath.read(doc, "$.publicString")));
-        assertTrue("expected \"publicInt\":42",
-                Integer.valueOf(42).equals(JsonPath.read(doc, "$.publicInt")));
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 2 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expected \"publicString\":\"abc\"", "abc".equals(JsonPath.read(doc, "$.publicString")));
+        assertTrue("expected \"publicInt\":42", Integer.valueOf(42).equals(JsonPath.read(doc, "$.publicInt")));
     }
 
     /**
@@ -452,22 +399,14 @@ public class JSONObjectTest {
                         Locale.getDefault());
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 2 items in top level map", docMap.size() == 2);
-        docMap = JsonPath.read(doc, "$.greetings");
-        assertTrue("expected 2 items in greetings map", docMap.size() == 2);
-        assertTrue("expected \"hello\":\"Hello, \"",
-                "Hello, ".equals(JsonPath.read(doc, "$.greetings.hello")));
-        assertTrue("expected \"world\":\"World!\"",
-                "World!".equals(JsonPath.read(doc, "$.greetings.world")));
-        docMap = JsonPath.read(doc, "$.farewells");
-        assertTrue("expected 2 items in farewells map", docMap.size() == 2);
-        assertTrue("expected \"later\":\"Later, \"",
-                "Later, ".equals(JsonPath.read(doc, "$.farewells.later")));
-        assertTrue("expected \"world\":\"World!\"",
-                "Alligator!".equals(JsonPath.read(doc, "$.farewells.gator")));
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 2 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expected 2 greetings items", ((Map<?,?>)(JsonPath.read(doc, "$.greetings"))).size() == 2);
+        assertTrue("expected \"hello\":\"Hello, \"", "Hello, ".equals(JsonPath.read(doc, "$.greetings.hello")));
+        assertTrue("expected \"world\":\"World!\"", "World!".equals(JsonPath.read(doc, "$.greetings.world")));
+        assertTrue("expected 2 farewells items", ((Map<?,?>)(JsonPath.read(doc, "$.farewells"))).size() == 2);
+        assertTrue("expected \"later\":\"Later, \"", "Later, ".equals(JsonPath.read(doc, "$.farewells.later")));
+        assertTrue("expected \"world\":\"World!\"", "Alligator!".equals(JsonPath.read(doc, "$.farewells.gator")));
     }
 
     /**
@@ -486,27 +425,15 @@ public class JSONObjectTest {
         jsonObject.accumulate("myArray", -23.45e7);
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 1 item in top level object", docMap.size() == 1);
-        List<?> docList = JsonPath.read(doc, "$.myArray");
-        assertTrue("expected 6 items in myArray", docList.size() == 6);
-        assertTrue("expected true",
-                Boolean.TRUE.equals(JsonPath.read(doc, "$.myArray[0]")));
-        assertTrue("expected false",
-                Boolean.FALSE.equals(JsonPath.read(doc, "$.myArray[1]")));
-        assertTrue("expected hello world!",
-                "hello world!".equals(JsonPath.read(doc, "$.myArray[2]")));
-        assertTrue("expected h\be\tllo w\u1234orld!",
-                "h\be\tllo w\u1234orld!".equals(JsonPath.read(doc,
-                        "$.myArray[3]")));
-        assertTrue("expected 42",
-                Integer.valueOf(42).equals(JsonPath.read(doc, "$.myArray[4]")));
-        assertTrue(
-                "expected -23.45e7",
-                Double.valueOf(-23.45e7).equals(
-                        JsonPath.read(doc, "$.myArray[5]")));
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 1 top level item", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 1);
+        assertTrue("expected 6 myArray items", ((List<?>)(JsonPath.read(doc, "$.myArray"))).size() == 6);
+        assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc, "$.myArray[0]")));
+        assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc, "$.myArray[1]")));
+        assertTrue("expected hello world!", "hello world!".equals(JsonPath.read(doc, "$.myArray[2]")));
+        assertTrue("expected h\be\tllo w\u1234orld!", "h\be\tllo w\u1234orld!".equals(JsonPath.read(doc,"$.myArray[3]")));
+        assertTrue("expected 42", Integer.valueOf(42).equals(JsonPath.read(doc, "$.myArray[4]")));
+        assertTrue("expected -23.45e7", Double.valueOf(-23.45e7).equals(JsonPath.read(doc, "$.myArray[5]")));
     }
 
     /**
@@ -524,27 +451,15 @@ public class JSONObjectTest {
         jsonObject.append("myArray", -23.45e7);
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 1 item in top level object", docMap.size() == 1);
-        List<?> docList = JsonPath.read(doc, "$.myArray");
-        assertTrue("expected 6 items in myArray", docList.size() == 6);
-        assertTrue("expected true",
-                Boolean.TRUE.equals(JsonPath.read(doc, "$.myArray[0]")));
-        assertTrue("expected false",
-                Boolean.FALSE.equals(JsonPath.read(doc, "$.myArray[1]")));
-        assertTrue("expected hello world!",
-                "hello world!".equals(JsonPath.read(doc, "$.myArray[2]")));
-        assertTrue("expected h\be\tllo w\u1234orld!",
-                "h\be\tllo w\u1234orld!".equals(JsonPath.read(doc,
-                        "$.myArray[3]")));
-        assertTrue("expected 42",
-                Integer.valueOf(42).equals(JsonPath.read(doc, "$.myArray[4]")));
-        assertTrue(
-                "expected -23.45e7",
-                Double.valueOf(-23.45e7).equals(
-                        JsonPath.read(doc, "$.myArray[5]")));
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 1 top level item", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 1);
+        assertTrue("expected 6 myArray items", ((List<?>)(JsonPath.read(doc, "$.myArray"))).size() == 6);
+        assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc, "$.myArray[0]")));
+        assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc, "$.myArray[1]")));
+        assertTrue("expected hello world!", "hello world!".equals(JsonPath.read(doc, "$.myArray[2]")));
+        assertTrue("expected h\be\tllo w\u1234orld!", "h\be\tllo w\u1234orld!".equals(JsonPath.read(doc,"$.myArray[3]")));
+        assertTrue("expected 42", Integer.valueOf(42).equals(JsonPath.read(doc, "$.myArray[4]")));
+        assertTrue("expected -23.45e7", Double.valueOf(-23.45e7).equals(JsonPath.read(doc, "$.myArray[5]")));
     }
 
     /**
@@ -1215,19 +1130,11 @@ public class JSONObjectTest {
         JSONArray jsonArray = jsonObject.names();
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonArray.toString());
-        List<?> docList = JsonPath.read(doc, "$");
-        assertTrue("expected 3 items in array", docList.size() == 3);
-        assertTrue(
-                "expected to find trueKey",
-                ((List<?>) JsonPath.read(doc, "$[?(@=='trueKey')]")).size() == 1);
-        assertTrue(
-                "expected to find falseKey",
-                ((List<?>) JsonPath.read(doc, "$[?(@=='falseKey')]")).size() == 1);
-        assertTrue(
-                "expected to find stringKey",
-                ((List<?>) JsonPath.read(doc, "$[?(@=='stringKey')]")).size() == 1);
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonArray.toString());
+        assertTrue("expected 3 top level items", ((List<?>)(JsonPath.read(doc, "$"))).size() == 3);
+        assertTrue("expected to find trueKey", ((List<?>) JsonPath.read(doc, "$[?(@=='trueKey')]")).size() == 1);
+        assertTrue("expected to find falseKey", ((List<?>) JsonPath.read(doc, "$[?(@=='falseKey')]")).size() == 1);
+        assertTrue("expected to find stringKey", ((List<?>) JsonPath.read(doc, "$[?(@=='stringKey')]")).size() == 1);
     }
 
     /**
@@ -1253,18 +1160,12 @@ public class JSONObjectTest {
         jsonObject.increment("keyFloat");
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 4 items in object", docMap.size() == 4);
-        assertTrue("expected to find keyInt:3",
-                Integer.valueOf(3).equals(JsonPath.read(doc, "$.keyInt")));
-        assertTrue(
-                "expected to find keyLong:9999999993",
-                Long.valueOf(9999999993L).equals(
-                        JsonPath.read(doc, "$.keyLong")));
-        assertTrue("expected to find keyDouble:3.1", Double.valueOf(3.1)
-                .equals(JsonPath.read(doc, "$.keyDouble")));
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 4 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 4);
+        assertTrue("expected 3", Integer.valueOf(3).equals(JsonPath.read(doc, "$.keyInt")));
+        assertTrue("expected 9999999993", Long.valueOf(9999999993L).equals(JsonPath.read(doc, "$.keyLong")));
+        assertTrue("expected 3.1", Double.valueOf(3.1).equals(JsonPath.read(doc, "$.keyDouble")));
+
         /**
          * Should work the same way on any platform! @see https://docs.oracle
          * .com/javase/specs/jls/se7/html/jls-4.html#jls-4.2.3 This is the
@@ -1288,10 +1189,7 @@ public class JSONObjectTest {
          * missing bits would not fit into the 32 bit float, i.e. the
          * information needed simply is not there!
          */
-        assertTrue(
-                "expected to find keyFloat:3.0999999046325684",
-                Double.valueOf(3.0999999046325684).equals(
-                        JsonPath.read(doc, "$.keyFloat")));
+        assertTrue("expected 3.0999999046325684", Double.valueOf(3.0999999046325684).equals(JsonPath.read(doc, "$.keyFloat")));
 
         /**
          * float f = 3.1f; double df = (double) f; double d = 3.1d;
@@ -1399,32 +1297,19 @@ public class JSONObjectTest {
         jsonObject.put("objectKey", myMap);
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 4 items in object", docMap.size() == 4);
-        assertTrue("expected to find trueKey:true",
-                Boolean.TRUE.equals(JsonPath.read(doc, "$.trueKey")));
-        assertTrue("expected to find falseKey:false",
-                Boolean.FALSE.equals(JsonPath.read(doc, "$.falseKey")));
-        List<?> docList = JsonPath.read(doc, "$.arrayKey");
-        assertTrue("expected 3 items in array", docList.size() == 3);
-        assertTrue("expected to find 0",
-                Integer.valueOf(0).equals(JsonPath.read(doc, "$.arrayKey[0]")));
-        assertTrue("expected to find 1",
-                Integer.valueOf(1).equals(JsonPath.read(doc, "$.arrayKey[1]")));
-        assertTrue("expected to find 2",
-                Integer.valueOf(2).equals(JsonPath.read(doc, "$.arrayKey[2]")));
-        docMap = JsonPath.read(doc,  "$.objectKey");
-        assertTrue("expected 4 items in object", docMap.size() == 4);
-        assertTrue("expected to find myKey1:myVal1",
-                "myVal1".equals(JsonPath.read(doc, "$.objectKey.myKey1")));
-        assertTrue("expected to find myKey2:myVal2",
-                "myVal2".equals(JsonPath.read(doc, "$.objectKey.myKey2")));
-        assertTrue("expected to find myKey3:myVal3",
-                "myVal3".equals(JsonPath.read(doc, "$.objectKey.myKey3")));
-        assertTrue("expected to find myKey4:myVal4",
-                "myVal4".equals(JsonPath.read(doc, "$.objectKey.myKey4")));
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 4 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 4);
+        assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc, "$.trueKey")));
+        assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc, "$.falseKey")));
+        assertTrue("expected 3 arrayKey items", ((List<?>)(JsonPath.read(doc, "$.arrayKey"))).size() == 3);
+        assertTrue("expected 0", Integer.valueOf(0).equals(JsonPath.read(doc, "$.arrayKey[0]")));
+        assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc, "$.arrayKey[1]")));
+        assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc, "$.arrayKey[2]")));
+        assertTrue("expected 4 objectKey items", ((Map<?,?>)(JsonPath.read(doc, "$.objectKey"))).size() == 4);
+        assertTrue("expected myVal1", "myVal1".equals(JsonPath.read(doc, "$.objectKey.myKey1")));
+        assertTrue("expected myVal2", "myVal2".equals(JsonPath.read(doc, "$.objectKey.myKey2")));
+        assertTrue("expected myVal3", "myVal3".equals(JsonPath.read(doc, "$.objectKey.myKey3")));
+        assertTrue("expected myVal4", "myVal4".equals(JsonPath.read(doc, "$.objectKey.myKey4")));
 
         jsonObject.remove("trueKey");
         JSONObject expectedJsonObject = new JSONObject(expectedStr);
@@ -1475,32 +1360,19 @@ public class JSONObjectTest {
         JSONObject jsonObject = new JSONObject(str);
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 4 items in object", docMap.size() == 4);
-        assertTrue("expected to find \"trueKey\":true",
-                Boolean.TRUE.equals(JsonPath.read(doc, "$.trueKey")));
-        assertTrue("expected to find \"falseKey\":false",
-                Boolean.FALSE.equals(JsonPath.read(doc, "$.falseKey")));
-        List<?> docList = JsonPath.read(doc, "$.arrayKey");
-        assertTrue("expected 3 array items", docList.size() == 3);
-        assertTrue("expected array value 0",
-                Integer.valueOf(0).equals(JsonPath.read(doc, "$.arrayKey[0]")));
-        assertTrue("expected array value 1",
-                Integer.valueOf(1).equals(JsonPath.read(doc, "$.arrayKey[1]")));
-        assertTrue("expected array value 2",
-                Integer.valueOf(2).equals(JsonPath.read(doc, "$.arrayKey[2]")));
-        docMap = JsonPath.read(doc, "$.objectKey");
-        assertTrue("expected 4 items in objectKey object", docMap.size() == 4);
-        assertTrue("expected objectKey myKey1:myVal1",
-                "myVal1".equals(JsonPath.read(doc, "$.objectKey.myKey1")));
-        assertTrue("expected objectKey myKey2:myVal2",
-                "myVal2".equals(JsonPath.read(doc, "$.objectKey.myKey2")));
-        assertTrue("expected objectKey myKey3:myVal3",
-                "myVal3".equals(JsonPath.read(doc, "$.objectKey.myKey3")));
-        assertTrue("expected objectKey myKey4:myVal4",
-                "myVal4".equals(JsonPath.read(doc, "$.objectKey.myKey4")));
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 4 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 4);
+        assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc, "$.trueKey")));
+        assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc, "$.falseKey")));
+        assertTrue("expected 3 arrayKey items", ((List<?>)(JsonPath.read(doc, "$.arrayKey"))).size() == 3);
+        assertTrue("expected 0", Integer.valueOf(0).equals(JsonPath.read(doc, "$.arrayKey[0]")));
+        assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc, "$.arrayKey[1]")));
+        assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc, "$.arrayKey[2]")));
+        assertTrue("expected 4 objectKey items", ((Map<?,?>)(JsonPath.read(doc, "$.objectKey"))).size() == 4);
+        assertTrue("expected myVal1", "myVal1".equals(JsonPath.read(doc, "$.objectKey.myKey1")));
+        assertTrue("expected myVal2", "myVal2".equals(JsonPath.read(doc, "$.objectKey.myKey2")));
+        assertTrue("expected myVal3", "myVal3".equals(JsonPath.read(doc, "$.objectKey.myKey3")));
+        assertTrue("expected myVal4", "myVal4".equals(JsonPath.read(doc, "$.objectKey.myKey4")));
     }
 
     /**
@@ -1518,14 +1390,10 @@ public class JSONObjectTest {
         jsonObject.put("key", map);
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 1 item in object", docMap.size() == 1);
-        docMap = JsonPath.read(doc, "$.key");
-        assertTrue("expected 1 item in key object", docMap.size() == 1);
-        assertTrue("expected abc:def",
-                "def".equals(JsonPath.read(doc, "$.key.abc")));
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 1 top level item", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 1);
+        assertTrue("expected 1 key item", ((Map<?,?>)(JsonPath.read(doc, "$.key"))).size() == 1);
+        assertTrue("expected def", "def".equals(JsonPath.read(doc, "$.key.abc")));
     }
 
     /**
@@ -1544,12 +1412,9 @@ public class JSONObjectTest {
         jsonObject.put("key", collection);
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 1 item in object", docMap.size() == 1);
-        List<?> docList = JsonPath.read(doc, "$.key");
-        assertTrue("expected 1 item in key object", docList.size() == 1);
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 1 top level item", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 1);
+        assertTrue("expected 1 key item", ((List<?>)(JsonPath.read(doc, "$.key"))).size() == 1);
         assertTrue("expected abc", "abc".equals(JsonPath.read(doc, "$.key[0]")));
     }
 
@@ -1613,12 +1478,9 @@ public class JSONObjectTest {
         // this is the test, it should not throw an exception
         String str = JSONObject.valueToString(myMap);
         // confirm result, just in case
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(str);
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 1 item in object", docMap.size() == 1);
-        assertTrue("expected myValue",
-                "myValue".equals(JsonPath.read(doc, "$.1")));
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(str);
+        assertTrue("expected 1 top level item", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 1);
+        assertTrue("expected myValue", "myValue".equals(JsonPath.read(doc, "$.1")));
     }
 
     /**
@@ -1667,44 +1529,29 @@ public class JSONObjectTest {
         JSONArray jsonArray = (JSONArray) (JSONObject.wrap(collection));
 
         // validate JSON
-        Object doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonArray.toString());
-        List<?> docList = JsonPath.read(doc, "$");
-        assertTrue("expected 3 items in array", docList.size() == 3);
-        assertTrue("expected 1",
-                Integer.valueOf(1).equals(JsonPath.read(doc, "$[0]")));
-        assertTrue("expected 2",
-                Integer.valueOf(2).equals(JsonPath.read(doc, "$[1]")));
-        assertTrue("expected 3",
-                Integer.valueOf(3).equals(JsonPath.read(doc, "$[2]")));
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonArray.toString());
+        assertTrue("expected 3 top level items", ((List<?>)(JsonPath.read(doc, "$"))).size() == 3);
+        assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc, "$[0]")));
+        assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc, "$[1]")));
+        assertTrue("expected 3", Integer.valueOf(3).equals(JsonPath.read(doc, "$[2]")));
 
         // wrap Array returns JSONArray
         Integer[] array = { new Integer(1), new Integer(2), new Integer(3) };
         JSONArray integerArrayJsonArray = (JSONArray)(JSONObject.wrap(array));
 
         // validate JSON
-        doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(jsonArray.toString());
-        docList = JsonPath.read(doc, "$");
-        assertTrue("expected 3 items in array", docList.size() == 3);
-        assertTrue("expected 1",
-                Integer.valueOf(1).equals(JsonPath.read(doc, "$[0]")));
-        assertTrue("expected 2",
-                Integer.valueOf(2).equals(JsonPath.read(doc, "$[1]")));
-        assertTrue("expected 3",
-                Integer.valueOf(3).equals(JsonPath.read(doc, "$[2]")));
+        doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonArray.toString());
+        assertTrue("expected 3 top level items", ((List<?>)(JsonPath.read(doc, "$"))).size() == 3);
+        assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc, "$[0]")));
+        assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc, "$[1]")));
+        assertTrue("expected 3", Integer.valueOf(3).equals(JsonPath.read(doc, "$[2]")));
 
         // validate JSON
-        doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(integerArrayJsonArray.toString());
-        docList = JsonPath.read(doc, "$");
-        assertTrue("expected 3 items in array", docList.size() == 3);
-        assertTrue("expected 1",
-                Integer.valueOf(1).equals(JsonPath.read(doc, "$[0]")));
-        assertTrue("expected 2",
-                Integer.valueOf(2).equals(JsonPath.read(doc, "$[1]")));
-        assertTrue("expected 3",
-                Integer.valueOf(3).equals(JsonPath.read(doc, "$[2]")));
+        doc = Configuration.defaultConfiguration().jsonProvider().parse(integerArrayJsonArray.toString());
+        assertTrue("expected 3 top level items", ((List<?>)(JsonPath.read(doc, "$"))).size() == 3);
+        assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc, "$[0]")));
+        assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc, "$[1]")));
+        assertTrue("expected 3", Integer.valueOf(3).equals(JsonPath.read(doc, "$[2]")));
 
         // wrap map returns JSONObject
         Map<String, String> map = new HashMap<String, String>();
@@ -1714,16 +1561,11 @@ public class JSONObjectTest {
         JSONObject mapJsonObject = (JSONObject) (JSONObject.wrap(map));
 
         // validate JSON
-        doc = Configuration.defaultConfiguration().jsonProvider()
-                .parse(mapJsonObject.toString());
-        Map<?, ?> docMap = JsonPath.read(doc, "$");
-        assertTrue("expected 3 items in object", docMap.size() == 3);
-        assertTrue("expected key1:val1",
-                "val1".equals(JsonPath.read(doc, "$.key1")));
-        assertTrue("expected key2:val2",
-                "val2".equals(JsonPath.read(doc, "$.key2")));
-        assertTrue("expected key3:val3",
-                "val3".equals(JsonPath.read(doc, "$.key3")));
+        doc = Configuration.defaultConfiguration().jsonProvider().parse(mapJsonObject.toString());
+        assertTrue("expected 3 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 3);
+        assertTrue("expected val1", "val1".equals(JsonPath.read(doc, "$.key1")));
+        assertTrue("expected val2", "val2".equals(JsonPath.read(doc, "$.key2")));
+        assertTrue("expected val3", "val3".equals(JsonPath.read(doc, "$.key3")));
 
         // TODO test wrap(package)
     }

--- a/JSONStringerTest.java
+++ b/JSONStringerTest.java
@@ -192,6 +192,7 @@ public class JSONStringerTest {
         String str = jsonStringer.toString();
         JSONObject jsonObject = new JSONObject(str);
 
+        // validate JSON content
         Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
         assertTrue("expected 7 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 7);
         assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc, "$.trueValue")));
@@ -221,6 +222,7 @@ public class JSONStringerTest {
         String str = jsonStringer.toString();
         JSONArray jsonArray = new JSONArray(str);
 
+        // validate JSON content
         Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonArray.toString());
         assertTrue("expected 6 top level items", ((List<?>)(JsonPath.read(doc, "$"))).size() == 6);
         assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc, "$[0]")));
@@ -272,6 +274,7 @@ public class JSONStringerTest {
         String str = jsonStringer.toString();
         JSONObject jsonObject = new JSONObject(str);
 
+        // validate JSON content
         Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
         assertTrue("expected 8 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 8);
         assertTrue("expected 4 object2 items", ((Map<?,?>)(JsonPath.read(doc, "$.object2"))).size() == 4);

--- a/JSONStringerTest.java
+++ b/JSONStringerTest.java
@@ -2,8 +2,12 @@ package org.json.junit;
 
 import static org.junit.Assert.*;
 
+import java.util.*;
+
 import org.json.*;
 import org.junit.Test;
+
+import com.jayway.jsonpath.*;
 
 
 /**
@@ -175,16 +179,6 @@ public class JSONStringerTest {
      */
     @Test
     public void simpleObjectString() {
-        String expectedStr = 
-            "{"+
-                "\"trueValue\":true,"+
-                "\"falseValue\":false,"+
-                "\"nullValue\":null,"+
-                "\"stringValue\":\"hello world!\","+
-                "\"complexStringValue\":\"h\be\tllo w\u1234orld!\","+
-                "\"intValue\":42,"+
-                "\"doubleValue\":-23.45e67"+
-            "}";
         JSONStringer jsonStringer = new JSONStringer();
         jsonStringer.object();
         jsonStringer.key("trueValue").value(true);
@@ -197,8 +191,16 @@ public class JSONStringerTest {
         jsonStringer.endObject();
         String str = jsonStringer.toString();
         JSONObject jsonObject = new JSONObject(str);
-        JSONObject expectedJsonObject = new JSONObject(expectedStr);
-        Util.compareActualVsExpectedJsonObjects(jsonObject, expectedJsonObject);
+
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 7 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 7);
+        assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc, "$.trueValue")));
+        assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc, "$.falseValue")));
+        assertTrue("expected null", null == JsonPath.read(doc, "$.nullValue"));
+        assertTrue("expected hello world!", "hello world!".equals(JsonPath.read(doc, "$.stringValue")));
+        assertTrue("expected h\be\tllo w\u1234orld!", "h\be\tllo w\u1234orld!".equals(JsonPath.read(doc, "$.complexStringValue")));
+        assertTrue("expected 42", Integer.valueOf(42).equals(JsonPath.read(doc, "$.intValue")));
+        assertTrue("expected -23.45e67", Double.valueOf(-23.45e67).equals(JsonPath.read(doc, "$.doubleValue")));
     }
 
     /**
@@ -207,15 +209,6 @@ public class JSONStringerTest {
      */
     @Test
     public void simpleArrayString() {
-        String expectedStr = 
-            "["+
-                "true,"+
-                "false,"+
-                "null,"+
-                "\"hello world!\","+
-                "42,"+
-                "-23.45e67"+
-            "]";
         JSONStringer jsonStringer = new JSONStringer();
         jsonStringer.array();
         jsonStringer.value(true);
@@ -227,8 +220,15 @@ public class JSONStringerTest {
         jsonStringer.endArray();
         String str = jsonStringer.toString();
         JSONArray jsonArray = new JSONArray(str);
-        JSONArray expectedJsonArray = new JSONArray(expectedStr);
-        Util.compareActualVsExpectedJsonArrays(jsonArray, expectedJsonArray);
+
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonArray.toString());
+        assertTrue("expected 6 top level items", ((List<?>)(JsonPath.read(doc, "$"))).size() == 6);
+        assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc, "$[0]")));
+        assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc, "$[1]")));
+        assertTrue("expected null", null == JsonPath.read(doc, "$[2]"));
+        assertTrue("expected hello world!", "hello world!".equals(JsonPath.read(doc, "$[3]")));
+        assertTrue("expected 42", Integer.valueOf(42).equals(JsonPath.read(doc, "$[4]")));
+        assertTrue("expected -23.45e67", Double.valueOf(-23.45e67).equals(JsonPath.read(doc, "$[5]")));
     }
 
     /**
@@ -237,38 +237,6 @@ public class JSONStringerTest {
      */
     @Test
     public void complexObjectString() {
-        String expectedStr = 
-            "{"+
-                "\"trueValue\":true,"+
-                "\"falseValue\":false,"+
-                "\"nullValue\":null,"+
-                "\"stringValue\":\"hello world!\","+
-                "\"object2\":{"+
-                    "\"k1\":\"v1\","+
-                    "\"k2\":\"v2\","+
-                    "\"k3\":\"v3\","+
-                    "\"array1\":["+
-                        "1,"+
-                        "2,"+
-                        "{"+
-                            "\"k4\":\"v4\","+
-                            "\"k5\":\"v5\","+
-                            "\"k6\":\"v6\","+
-                            "\"array2\":["+
-                                "5,"+
-                                "6,"+
-                                "7,"+
-                                "8"+
-                            "]"+
-                        "},"+
-                        "3,"+
-                        "4"+
-                    "]"+
-                "},"+
-                "\"complexStringValue\":\"h\be\tllo w\u1234orld!\","+
-                "\"intValue\":42,"+
-                "\"doubleValue\":-23.45e67"+
-            "}";
         JSONStringer jsonStringer = new JSONStringer();
         jsonStringer.object();
         jsonStringer.key("trueValue").value(true);
@@ -303,8 +271,34 @@ public class JSONStringerTest {
         jsonStringer.endObject();
         String str = jsonStringer.toString();
         JSONObject jsonObject = new JSONObject(str);
-        JSONObject expectedJsonObject = new JSONObject(expectedStr);
-        Util.compareActualVsExpectedJsonObjects(jsonObject, expectedJsonObject);
+
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 8 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 8);
+        assertTrue("expected 4 object2 items", ((Map<?,?>)(JsonPath.read(doc, "$.object2"))).size() == 4);
+        assertTrue("expected 5 array1 items", ((List<?>)(JsonPath.read(doc, "$.object2.array1"))).size() == 5);
+        assertTrue("expected 4 array[2] items", ((Map<?,?>)(JsonPath.read(doc, "$.object2.array1[2]"))).size() == 4);
+        assertTrue("expected 4 array1[2].array2 items", ((List<?>)(JsonPath.read(doc, "$.object2.array1[2].array2"))).size() == 4);
+        assertTrue("expected true", Boolean.TRUE.equals(JsonPath.read(doc, "$.trueValue")));
+        assertTrue("expected false", Boolean.FALSE.equals(JsonPath.read(doc, "$.falseValue")));
+        assertTrue("expected null", null == JsonPath.read(doc, "$.nullValue"));
+        assertTrue("expected hello world!", "hello world!".equals(JsonPath.read(doc, "$.stringValue")));
+        assertTrue("expected 42", Integer.valueOf(42).equals(JsonPath.read(doc, "$.intValue")));
+        assertTrue("expected -23.45e67", Double.valueOf(-23.45e67).equals(JsonPath.read(doc, "$.doubleValue")));
+        assertTrue("expected h\be\tllo w\u1234orld!", "h\be\tllo w\u1234orld!".equals(JsonPath.read(doc, "$.complexStringValue")));
+        assertTrue("expected v1", "v1".equals(JsonPath.read(doc, "$.object2.k1")));
+        assertTrue("expected v2", "v2".equals(JsonPath.read(doc, "$.object2.k2")));
+        assertTrue("expected v3", "v3".equals(JsonPath.read(doc, "$.object2.k3")));
+        assertTrue("expected 1", Integer.valueOf(1).equals(JsonPath.read(doc, "$.object2.array1[0]")));
+        assertTrue("expected 2", Integer.valueOf(2).equals(JsonPath.read(doc, "$.object2.array1[1]")));
+        assertTrue("expected v4", "v4".equals(JsonPath.read(doc, "$.object2.array1[2].k4")));
+        assertTrue("expected v5", "v5".equals(JsonPath.read(doc, "$.object2.array1[2].k5")));
+        assertTrue("expected v6", "v6".equals(JsonPath.read(doc, "$.object2.array1[2].k6")));
+        assertTrue("expected 5", Integer.valueOf(5).equals(JsonPath.read(doc, "$.object2.array1[2].array2[0]")));
+        assertTrue("expected 6", Integer.valueOf(6).equals(JsonPath.read(doc, "$.object2.array1[2].array2[1]")));
+        assertTrue("expected 7", Integer.valueOf(7).equals(JsonPath.read(doc, "$.object2.array1[2].array2[2]")));
+        assertTrue("expected 8", Integer.valueOf(8).equals(JsonPath.read(doc, "$.object2.array1[2].array2[3]")));
+        assertTrue("expected 3", Integer.valueOf(3).equals(JsonPath.read(doc, "$.object2.array1[3]")));
+        assertTrue("expected 4", Integer.valueOf(4).equals(JsonPath.read(doc, "$.object2.array1[4]")));
     }
 
 }


### PR DESCRIPTION
Starting with JSONObjectTest. The new code is a bit tedious to write, but the validation is exact. In a few tests, improvements were made, due to using JsonPath. 

The following files are not changed, since the tests as written illustrate the transformations better than the new code would.
CDLTest
CookieTest
HTTPTest
JSONMLTest
XMLTest
