### PR TITLE
Document how JSONObject works with nested bean classes

### DIFF
--- a/src/test/org/json/junit/JSONObjectTest.java
+++ b/src/test/org/json/junit/JSONObjectTest.java
@@ -340,6 +340,27 @@ public class JSONObjectTest {
     }
 
     /**
+     * JSONObject built from a nested bean. Establish and document the behavior when
+     * a bean-style class which contains another bean-style nested class is
+     * serialized. 
+     */
+    @Test
+    public void jsonObjectByNestedBean() {
+        MyNestedClass myNestedClass = new MyNestedClass("nested", 123);
+        MyNestingClass myNestingClass = new MyNestingClass("nesting", myNestedClass);
+        JSONObject jsonObject = new JSONObject(myNestingClass);
+        String str = jsonObject.toString();
+
+        // validate JSON
+        Object doc = Configuration.defaultConfiguration().jsonProvider().parse(jsonObject.toString());
+        assertTrue("expected 2 top level items", ((Map<?,?>)(JsonPath.read(doc, "$"))).size() == 2);
+        assertTrue("expected nesting", "nesting".equals(JsonPath.read(doc, "$.str")));
+        assertTrue("expected 2 nested items", ((Map<?,?>)(JsonPath.read(doc, "$.myNestedClass"))).size() == 2);
+        assertTrue("expected nestedStr", "nested".equals(JsonPath.read(doc, "$.myNestedClass.nestedStr")));
+        assertTrue("expected 123", Integer.valueOf("123").equals(JsonPath.read(doc, "$.myNestedClass.nestedInt")));
+    }
+
+    /**
      * Exercise the JSONObject from resource bundle functionality.
      * The test resource bundle is uncomplicated, but provides adequate test coverage.
      */

--- a/src/test/org/json/junit/MyNestedClass.java
+++ b/src/test/org/json/junit/MyNestedClass.java
@@ -1,0 +1,22 @@
+package org.json.junit;
+
+public class MyNestedClass {
+    String nestedStr;
+    Integer nestedInt;
+    public MyNestedClass(String nestedStr, Integer nestedInt) {
+        this.nestedStr = nestedStr;
+        this.nestedInt = nestedInt;
+    }
+    public String getNestedStr() {
+        return nestedStr;
+    }
+    public void setNestedStr(String nestedStr) {
+        this.nestedStr = nestedStr;
+    }
+    public Integer getNestedInt() {
+        return nestedInt;
+    }
+    public void setNestedInt(Integer nestedInt) {
+        this.nestedInt = nestedInt;
+    }
+}

--- a/src/test/org/json/junit/MyNestingClass.java
+++ b/src/test/org/json/junit/MyNestingClass.java
@@ -1,0 +1,23 @@
+package org.json.junit;
+
+public class MyNestingClass {
+    private String str;
+    private MyNestedClass myNestedClass;
+    public MyNestingClass(String str, MyNestedClass myNestedClass) {
+        this.str = str;
+        this.myNestedClass = myNestedClass;
+    }
+    public String getStr() {
+        return str;
+    }
+    public void setStr(String str) {
+        this.str = str;
+    }
+    public MyNestedClass getMyNestedClass() {
+        return myNestedClass;
+    }
+    public void setMyNestedClass(MyNestedClass myNestedClass) {
+        this.myNestedClass = myNestedClass;
+    }
+
+}


### PR DESCRIPTION
In response to an issue in JSON-Java, JSONObjectTest checks the behavior when a nested class with getters and settings is serialized. Don't see any problems with it. JSONArray, on the other hand, does not support this type of serialization.
