### PR TITLE
Locale tests for non en keys

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,12 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'jacoco'
 
+tasks.withType(JavaCompile) { 
+     // this subproject requires -parameters option
+     options.compilerArgs << '-parameters'
+     options.encoding = 'UTF-8' 
+}
+
 sourceSets {
   // Uncomment main if you have merged JSON-Java and JSON-Java-unit-test code
   main

--- a/src/test/java/org/json/junit/JSONObjectLocaleTest.java
+++ b/src/test/java/org/json/junit/JSONObjectLocaleTest.java
@@ -14,35 +14,42 @@ import org.junit.*;
  */
 public class JSONObjectLocaleTest {
     /**
-     * JSONObject built from a bean with locale-specific keys - that is, the key
-     * fields are not LANG_ENGLISH.
+     * JSONObject built from a bean with locale-specific keys.
+     * In the Turkish alphabet, there are 2 versions of the letter "i".
+     * 'eh' I ı (dotless i)
+     * 'ee' İ i (dotted i)
+     * A problem can occur when parsing the public get methods for a bean.
+     * If the method starts with getI... then the key name will be lowercased
+     * to 'i' in English, and 'ı' in Turkish.
+     * We want the keys to be consistent regardless of locale, so JSON-Java
+     * lowercase operations are made to be locale-neutral by specifying
+     * Locale.ROOT. This causes 'I' to be universally lowercased to 'i'
+     * regardless of the locale currently in effect.
      */
     @Test
     public void jsonObjectByLocaleBean() {
 
         MyLocaleBean myLocaleBean = new MyLocaleBean();
 
+        /**
+         * This is just the control case which happens when the locale.ROOT
+         * lowercasing behavior is the same as the current locale.
+         */
         Locale.setDefault(new Locale("en"));
         JSONObject jsonen = new JSONObject(myLocaleBean);
-        System.out.println("jsonen " + jsonen);
+        assertEquals("expected size 2, found: " +jsonen.length(), 2, jsonen.length());
+        assertEquals("expected jsonen[i] == beanI", "beanI", jsonen.getString("i"));
+        assertEquals("expected jsonen[id] == beanId", "beanId", jsonen.getString("id"));
 
+        /**
+         * Without the JSON-Java change, these keys would be stored internally as
+         * starting with the letter, 'ı' (dotless i), since the lowercasing of
+         * the getI and getId keys would be specific to the Turkish locale.
+         */
         Locale.setDefault(new Locale("tr"));
         JSONObject jsontr = new JSONObject(myLocaleBean);
-        System.out.println("jsontr " + jsontr);
-        /**
-         * In this test we exercise code that handles keys of 1-char and
-         * multi-char length that include text from a non-English locale.
-         * Turkish in this case. The JSONObject code should correctly retain the
-         * non-EN_LANG chars in the key.
-         */
-        assertTrue("expected beanId",
-                "Tlocaleüx".equals(jsonObject.getString("")));
-        assertTrue("expected Tlocalü",
-                "Tlocaleü".equals(jsonObject.getString("ü")));
-        assertTrue("expected Tlocaleüx",
-                "Tlocaleüx".equals((String)(jsonObject.query("/üx"))));
-        assertTrue("expected Tlocalü",
-                "Tlocaleü".equals((String)(jsonObject.query("/ü"))));
+        assertEquals("expected size 2, found: " +jsontr.length(), 2, jsontr.length());
+        assertEquals("expected jsontr[i] == beanI", "beanI", jsontr.getString("i"));
+        assertEquals("expected jsontr[id] == beanId", "beanId", jsontr.getString("id"));
     }
-
 }

--- a/src/test/java/org/json/junit/JSONObjectLocaleTest.java
+++ b/src/test/java/org/json/junit/JSONObjectLocaleTest.java
@@ -1,0 +1,48 @@
+package org.json.junit;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.json.*;
+import org.junit.*;
+
+/**
+ * Note: This file is saved as UTF-8. Do not save as ASCII or the tests will
+ * fail.
+ *
+ */
+public class JSONObjectLocaleTest {
+    /**
+     * JSONObject built from a bean with locale-specific keys - that is, the key
+     * fields are not LANG_ENGLISH.
+     */
+    @Test
+    public void jsonObjectByLocaleBean() {
+
+        MyLocaleBean myLocaleBean = new MyLocaleBean();
+
+        Locale.setDefault(new Locale("en"));
+        JSONObject jsonen = new JSONObject(myLocaleBean);
+        System.out.println("jsonen " + jsonen);
+
+        Locale.setDefault(new Locale("tr"));
+        JSONObject jsontr = new JSONObject(myLocaleBean);
+        System.out.println("jsontr " + jsontr);
+        /**
+         * In this test we exercise code that handles keys of 1-char and
+         * multi-char length that include text from a non-English locale.
+         * Turkish in this case. The JSONObject code should correctly retain the
+         * non-EN_LANG chars in the key.
+         */
+        assertTrue("expected beanId",
+                "Tlocaleüx".equals(jsonObject.getString("")));
+        assertTrue("expected Tlocalü",
+                "Tlocaleü".equals(jsonObject.getString("ü")));
+        assertTrue("expected Tlocaleüx",
+                "Tlocaleüx".equals((String)(jsonObject.query("/üx"))));
+        assertTrue("expected Tlocalü",
+                "Tlocaleü".equals((String)(jsonObject.query("/ü"))));
+    }
+
+}

--- a/src/test/java/org/json/junit/JunitTestSuite.java
+++ b/src/test/java/org/json/junit/JunitTestSuite.java
@@ -13,6 +13,7 @@ import org.junit.runners.Suite;
    HTTPTest.class,
    JSONStringerTest.class,
    JSONObjectTest.class,
+   JSONObjectLocaleTest.class,
    JSONArrayTest.class,
    EnumTest.class,
    JSONPointerTest.class,

--- a/src/test/java/org/json/junit/MyLocaleBean.java
+++ b/src/test/java/org/json/junit/MyLocaleBean.java
@@ -1,0 +1,12 @@
+package org.json.junit;
+
+public class MyLocaleBean {
+    private final String id = "beanId";
+    private final String i = "beanI";
+    public String getId() {
+        return id;
+    }
+    public String getI() {
+        return i;
+    }
+}


### PR DESCRIPTION
This will break unit tests until JSON-Java https://github.com/stleary/JSON-java/pull/317 is committed.
JSONObjectLocalTest.java is saved as UTF-8 else the javadoc could not be displayed correctly.
A new test module was added because I did not want to save the entire JSONObjectTest as UTF-8. 