### PR TITLE
Correct expected position information in error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,24 +101,26 @@ A unit test has the following stages:
 | CDL.java | 98.8% | Reasonable test cases.  |
 | Cookie.java  | 98.9%   | Reasonable test cases. |
 | CookieList.java |96.5% | Reasonable test cases. |
-| EnumTest.java | n/a | Just documenting how enums are handled. |
-| HTTP.java | 98.7%| Coverage > 90% | 
+| HTTP.java | 98.8%| Coverage > 90% | 
 | HTTPTokener.java |93.2% | No test   | 
-| JSONArray.java |95.9% | Reasonable test cases | 
-| JSONException.java | 26.7% | No test |
-| JSONML.java | 86.8%| In progress | 
-| JSONObject | 94.0% | Reasonable test cases | 
-| JSONObject.Null | 87.5% | No test  | 
+| JSONArray.java |88.3% | Reasonable test cases. Need new tests for newer API functions | 
+| JSONException.java | 100% | No test |
+| JSONML.java | 84.4%| In progress | 
+| JSONObject | 96.7% | Reasonable test cases | 
+| JSONObject.Null | 77.8% | No test  | 
+| JSONPointer | 96.3% | Reasonable test cases  | 
+| JSONPointerException | 100% | No test  | 
 | JSONString.java | | No test  | 
 | JSONStringer.java | 93.8%| Coverage > 90% | 
-| JSONTokener.java | 72.1% | In progress | 
-| JSONWriter.java | 87.5% | No test | 
-| Property.java  | 94.8%  | Coverage > 90% |
-| XML.java | 87.4% | In progress |
-| XMLTokener.java| 82.7%| No test  | 
+| JSONTokener.java | 87.5% | In progress | 
+| JSONWriter.java | 89.15% | No test | 
+| Property.java  | 95.8%  | Coverage > 90% |
+| XML.java | 77.3% | In progress |
+| XMLTokener.java| 82.4%| No test  | 
 
 | Files used in test |
 | ------------- |  
+| EnumTest.java |
 | MyBean.java |
 | MyBigNumberBean.java |
 | MyEnum.java |

--- a/src/test/java/org/json/junit/CDLTest.java
+++ b/src/test/java/org/json/junit/CDLTest.java
@@ -81,7 +81,7 @@ public class CDLTest {
             fail("Expecting an exception");
         } catch (JSONException e) {
             assertEquals("Expecting an exception message",
-                    "Missing close quote '\"'. at 22 [character 11 line 3]",
+                    "Missing close quote '\"'. at 22 [character 11 line 2]",
                     e.getMessage());
             
         }
@@ -117,7 +117,7 @@ public class CDLTest {
                fail("Expecting an exception");
            } catch (JSONException e) {
                assertEquals("Expecting an exception message",
-                       "Missing close quote '\"'. at 26 [character 15 line 3]",
+                       "Missing close quote '\"'. at 26 [character 15 line 2]",
                        e.getMessage());
                
            }
@@ -168,7 +168,7 @@ public class CDLTest {
                } catch (JSONException e) {
             	   System.out.println("Message" + e.getMessage());
                    assertEquals("Expecting an exception message",
-                           "Bad character 'V' (86). at 20 [character 9 line 3]",
+                           "Bad character 'V' (86). at 20 [character 9 line 2]",
                            e.getMessage());
                    
                }

--- a/src/test/java/org/json/junit/CDLTest.java
+++ b/src/test/java/org/json/junit/CDLTest.java
@@ -61,11 +61,11 @@ public class CDLTest {
         String badLine = "Col1, \"Col2\nVal1, Val2";
         try {
             CDL.toJSONArray(badLine);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                    "Missing close quote '\"'. at 12 [character 0 line 2]".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                    "Missing close quote '\"'. at 12 [character 0 line 2]",
+                    e.getMessage());
         }
     }
     
@@ -78,11 +78,11 @@ public class CDLTest {
         String badLine = "Col1, Col2\n\"Val1, Val2";
         try {
             CDL.toJSONArray(badLine);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                    "Missing close quote '\"'. at 23 [character 12 line 3]".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                    "Missing close quote '\"'. at 22 [character 11 line 3]",
+                    e.getMessage());
             
         }
     }
@@ -96,11 +96,11 @@ public class CDLTest {
         String badLine = "C\0ol1, Col2\nVal1, Val2";
         try {
             CDL.toJSONArray(badLine);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                    "Bad character 'o' (111). at 3 [character 4 line 1]".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                    "Bad character 'o' (111). at 2 [character 3 line 1]",
+                    e.getMessage());
             
         }
     }
@@ -114,11 +114,11 @@ public class CDLTest {
     	   String badLine = "Col1, Col2\n\"Val1, \"\"Val2\"\"";
            try {
                CDL.toJSONArray(badLine);
-               assertTrue("Expecting an exception", false);
+               fail("Expecting an exception");
            } catch (JSONException e) {
-               assertTrue("Expecting an exception message",
-                       "Missing close quote '\"'. at 27 [character 16 line 3]".
-                       equals(e.getMessage()));
+               assertEquals("Expecting an exception message",
+                       "Missing close quote '\"'. at 26 [character 15 line 3]",
+                       e.getMessage());
                
            }
     }
@@ -128,7 +128,7 @@ public class CDLTest {
      */
     @Test
     public void singleEscapedQuote(){
-    	       String singleEscape = "Col1, Col2\nVal1, \"\"\"Val2\"";
+               String singleEscape = "Col1, Col2\nVal1, \"\"\"Val2\"";
                JSONArray jsonArray = CDL.toJSONArray(singleEscape);
                
                String cdlStr = CDL.toString(jsonArray);
@@ -136,7 +136,22 @@ public class CDLTest {
                assertTrue(cdlStr.contains("Col2"));
                assertTrue(cdlStr.contains("Val1"));
                assertTrue(cdlStr.contains("\"Val2"));
+    }
+    
+    /**
+     * Assert that there is no error for a single escaped quote within a properly
+     * embedded quote when not the last value.
+     */
+    @Test
+    public void singleEscapedQuoteMiddleString(){
+               String singleEscape = "Col1, Col2\nVal1, \"\"\"Val2\"\nVal 3,Val 4";
+               JSONArray jsonArray = CDL.toJSONArray(singleEscape);
                
+               String cdlStr = CDL.toString(jsonArray);
+               assertTrue(cdlStr.contains("Col1"));
+               assertTrue(cdlStr.contains("Col2"));
+               assertTrue(cdlStr.contains("Val1"));
+               assertTrue(cdlStr.contains("\"Val2"));
     }
     
     /**
@@ -149,12 +164,12 @@ public class CDLTest {
     	       
     	       try {
                    CDL.toJSONArray(badLine);
-                   assertTrue("Expecting an exception", false);
+                   fail("Expecting an exception");
                } catch (JSONException e) {
             	   System.out.println("Message" + e.getMessage());
-                   assertTrue("Expecting an exception message",
-                           "Bad character 'V' (86). at 20 [character 9 line 3]".
-                           equals(e.getMessage()));
+                   assertEquals("Expecting an exception message",
+                           "Bad character 'V' (86). at 20 [character 9 line 3]",
+                           e.getMessage());
                    
                }
                
@@ -186,8 +201,8 @@ public class CDLTest {
     public void onlyColumnNames() {
         String columnNameStr = "col1, col2, col3";
         JSONArray jsonArray = CDL.toJSONArray(columnNameStr);
-        assertTrue("CDL should return null when only 1 row is given",
-                jsonArray == null);
+        assertNull("CDL should return null when only 1 row is given",
+                jsonArray);
     }
 
     /**
@@ -197,8 +212,8 @@ public class CDLTest {
     public void emptyLinesToJSONArray() {
         String str = " , , , \n , , , ";
         JSONArray jsonArray = CDL.toJSONArray(str);
-        assertTrue("JSONArray should be null for no content",
-                jsonArray == null);
+        assertNull("JSONArray should be null for no content",
+                jsonArray);
     }
 
     /**
@@ -208,8 +223,8 @@ public class CDLTest {
     public void emptyJSONArrayToString() {
         JSONArray jsonArray = new JSONArray();
         String str = CDL.toString(jsonArray);
-        assertTrue("CDL should return null for toString(null)",
-                str == null);
+        assertNull("CDL should return null for toString(null)",
+                str);
     }
 
     /**
@@ -218,8 +233,8 @@ public class CDLTest {
     @Test
     public void nullJSONArraysToString() {
         String str = CDL.toString(null, null);
-        assertTrue("CDL should return null for toString(null)",
-                str == null);
+        assertNull("CDL should return null for toString(null)",
+                str);
     }
 
     /**

--- a/src/test/java/org/json/junit/CookieListTest.java
+++ b/src/test/java/org/json/junit/CookieListTest.java
@@ -47,14 +47,14 @@ public class CookieListTest {
         String cookieStr = "thisCookieHasNoEqualsChar";
         try {
             CookieList.toJSONObject(cookieStr);
-            assertTrue("should throw an exception", false);
+            fail("should throw an exception");
         } catch (JSONException e) {
             /**
              * Not sure of the missing char, but full string compare fails 
              */
-            assertTrue("Expecting an exception message",
-                    e.getMessage().startsWith("Expected '=' and instead saw '") &&
-                            e.getMessage().endsWith("' at 27 [character 28 line 1]"));
+            assertEquals("Expecting an exception message",
+                    "Expected '=' and instead saw '' at 25 [character 26 line 1]",
+                    e.getMessage());
         }
     }
 

--- a/src/test/java/org/json/junit/CookieTest.java
+++ b/src/test/java/org/json/junit/CookieTest.java
@@ -43,11 +43,11 @@ public class CookieTest {
         String cookieStr = "thisCookieHasNoEqualsChar";
         try {
             Cookie.toJSONObject(cookieStr);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                    e.getMessage().startsWith("Expected '=' and instead saw '")
-                    && e.getMessage().endsWith("' at 27 [character 28 line 1]"));
+            assertEquals("Expecting an exception message",
+                    "Expected '=' and instead saw '' at 25 [character 26 line 1]",
+                    e.getMessage());
         }
     }
 
@@ -61,11 +61,11 @@ public class CookieTest {
         String cookieStr = "this=Cookie;myAttribute";
         try {
             Cookie.toJSONObject(cookieStr);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                    "Missing '=' in cookie parameter. at 25 [character 26 line 1]".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                    "Missing '=' in cookie parameter. at 23 [character 24 line 1]",
+                    e.getMessage());
         }
     }
 
@@ -79,11 +79,11 @@ public class CookieTest {
         String cookieStr = "";
         try {
             Cookie.toJSONObject(cookieStr);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                    e.getMessage().startsWith("Expected '=' and instead saw '") &&
-                    e.getMessage().endsWith("' at 2 [character 3 line 1]"));
+            assertEquals("Expecting an exception message",
+                    "Expected '=' and instead saw '' at 0 [character 1 line 1]",
+                    e.getMessage());
         }
     }
 

--- a/src/test/java/org/json/junit/JSONArrayTest.java
+++ b/src/test/java/org/json/junit/JSONArrayTest.java
@@ -74,9 +74,9 @@ public class JSONArrayTest {
         try {
             assertNull("Should throw an exception", new JSONArray(str));
         } catch (JSONException e) {
-            assertTrue("Expected an exception message", 
-                    "A JSONArray text must start with '[' at 1 [character 2 line 1]".
-                    equals(e.getMessage()));
+            assertEquals("Expected an exception message", 
+                    "A JSONArray text must start with '[' at 0 [character 1 line 1]",
+                    e.getMessage());
         }
     }
 

--- a/src/test/java/org/json/junit/JSONMLTest.java
+++ b/src/test/java/org/json/junit/JSONMLTest.java
@@ -98,7 +98,7 @@ public class JSONMLTest {
             fail("Expecting an exception");
         } catch (JSONException e) {
             assertEquals("Expecting an exception message",
-                "Bad XML at 24 [character 25 line 1]",
+                "Bad XML at 23 [character 24 line 1]",
                 e.getMessage());
         }
     }
@@ -226,7 +226,7 @@ public class JSONMLTest {
             fail("Expecting an exception");
         } catch (JSONException e) {
             assertEquals("Expecting an exception message",
-                "Misshaped meta tag at 216 [character 13 line 7]",
+                "Misshaped meta tag at 215 [character 12 line 7]",
                 e.getMessage());
         }
     }
@@ -256,7 +256,7 @@ public class JSONMLTest {
             fail("Expecting an exception");
         } catch (JSONException e) {
             assertEquals("Expecting an exception message",
-                "Misshaped meta tag at 215 [character 13 line 7]",
+                "Misshaped meta tag at 214 [character 12 line 7]",
                 e.getMessage());
         }
     }

--- a/src/test/java/org/json/junit/JSONMLTest.java
+++ b/src/test/java/org/json/junit/JSONMLTest.java
@@ -98,7 +98,7 @@ public class JSONMLTest {
             fail("Expecting an exception");
         } catch (JSONException e) {
             assertEquals("Expecting an exception message",
-                "Bad XML at 23 [character 24 line 1]",
+                "Bad XML at 24 [character 25 line 1]",
                 e.getMessage());
         }
     }

--- a/src/test/java/org/json/junit/JSONMLTest.java
+++ b/src/test/java/org/json/junit/JSONMLTest.java
@@ -42,11 +42,11 @@ public class JSONMLTest {
         String xmlStr = "";
         try {
             JSONML.toJSONArray(xmlStr);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                "Bad XML at 1 [character 2 line 1]".
-                equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                "Bad XML at 0 [character 1 line 1]",
+                e.getMessage());
         }
     }
 
@@ -95,11 +95,11 @@ public class JSONMLTest {
         String xmlStr = "{ \"this is\": \"not xml\"}";
         try {
             JSONML.toJSONArray(xmlStr);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                "Bad XML at 25 [character 26 line 1]".
-                equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                "Bad XML at 23 [character 24 line 1]",
+                e.getMessage());
         }
     }
 
@@ -198,11 +198,11 @@ public class JSONMLTest {
             "</addresses>";
         try {
             JSONML.toJSONArray(xmlStr);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                "Misshaped tag at 176 [character 14 line 7]".
-                equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                "Misshaped tag at 176 [character 14 line 4]",
+                e.getMessage());
         }
     }
 
@@ -223,11 +223,11 @@ public class JSONMLTest {
             "</addresses>";
         try {
             JSONML.toJSONArray(xmlStr);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                "Misshaped meta tag at 216 [character 13 line 11]".
-                equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                "Misshaped meta tag at 216 [character 13 line 7]",
+                e.getMessage());
         }
     }
 
@@ -253,11 +253,11 @@ public class JSONMLTest {
             "</addresses>";
         try {
             JSONML.toJSONArray(xmlStr);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                "Misshaped meta tag at 215 [character 13 line 11]".
-                equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                "Misshaped meta tag at 215 [character 13 line 7]",
+                e.getMessage());
         }
     }
 
@@ -283,11 +283,11 @@ public class JSONMLTest {
             "</addresses>";
         try {
             JSONML.toJSONArray(xmlStr);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                "Misplaced '<' at 194 [character 5 line 10]".
-                equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                "Misplaced '<' at 194 [character 5 line 6]",
+                e.getMessage());
         }
     }
 
@@ -343,11 +343,11 @@ public class JSONMLTest {
             "</addresses>";
         try {
             JSONML.toJSONArray(xmlStr);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                "Misplaced '<' at 206 [character 1 line 12]".
-                equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                "Misplaced '<' at 206 [character 1 line 7]",
+                e.getMessage());
         }
     }
 
@@ -373,11 +373,11 @@ public class JSONMLTest {
             "</addresses>";
         try {
             JSONML.toJSONArray(xmlStr);
-            assertTrue("Expecting an exception", false);
+            fail("Expecting an exception");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                "Expected 'CDATA[' at 204 [character 11 line 9]".
-                equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                "Expected 'CDATA[' at 204 [character 11 line 5]",
+                e.getMessage());
         }
     }
 

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -1853,36 +1853,36 @@ public class JSONObjectTest {
             String str = "abc";
             assertNull("Expected an exception",new JSONObject(str));
         } catch (JSONException e) { 
-            assertTrue("Expecting an exception message", 
-                    "A JSONObject text must begin with '{' at 1 [character 2 line 1]".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message", 
+                    "A JSONObject text must begin with '{' at 1 [character 2 line 1]",
+                    e.getMessage());
         }
         try {
             // does not end with '}'
             String str = "{";
             assertNull("Expected an exception",new JSONObject(str));
         } catch (JSONException e) { 
-            assertTrue("Expecting an exception message", 
-                    "A JSONObject text must end with '}' at 2 [character 3 line 1]".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message", 
+                    "A JSONObject text must end with '}' at 1 [character 2 line 1]",
+                    e.getMessage());
         }
         try {
             // key with no ':'
             String str = "{\"myKey\" = true}";
             assertNull("Expected an exception",new JSONObject(str));
         } catch (JSONException e) { 
-            assertTrue("Expecting an exception message", 
-                    "Expected a ':' after a key at 10 [character 11 line 1]".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message", 
+                    "Expected a ':' after a key at 10 [character 11 line 1]",
+                    e.getMessage());
         }
         try {
             // entries with no ',' separator
             String str = "{\"myKey\":true \"myOtherKey\":false}";
             assertNull("Expected an exception",new JSONObject(str));
         } catch (JSONException e) { 
-            assertTrue("Expecting an exception message", 
-                    "Expected a ',' or '}' at 15 [character 16 line 1]".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message", 
+                    "Expected a ',' or '}' at 15 [character 16 line 1]",
+                    e.getMessage());
         }
         try {
             // append to wrong key
@@ -1891,9 +1891,9 @@ public class JSONObjectTest {
             jsonObject.append("myKey", "hello");
             fail("Expected an exception");
         } catch (JSONException e) { 
-            assertTrue("Expecting an exception message",
-                    "JSONObject[myKey] is not a JSONArray.".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                    "JSONObject[myKey] is not a JSONArray.",
+                    e.getMessage());
         }
         try {
             // increment wrong key
@@ -1902,9 +1902,9 @@ public class JSONObjectTest {
             jsonObject.increment("myKey");
             fail("Expected an exception");
         } catch (JSONException e) { 
-            assertTrue("Expecting an exception message",
-                    "Unable to increment [\"myKey\"].".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                    "Unable to increment [\"myKey\"].",
+                    e.getMessage());
         }
         try {
             // invalid key
@@ -1913,18 +1913,18 @@ public class JSONObjectTest {
             jsonObject.get(null);
             fail("Expected an exception");
         } catch (JSONException e) { 
-            assertTrue("Expecting an exception message",
-                    "Null key.".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                    "Null key.",
+                    e.getMessage());
         }
         try {
             // invalid numberToString()
             JSONObject.numberToString((Number)null);
             fail("Expected an exception");
         } catch (JSONException e) { 
-            assertTrue("Expecting an exception message", 
-                    "Null pointer".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message", 
+                    "Null pointer",
+                    e.getMessage());
         }
         try {
             // null put key 

--- a/src/test/java/org/json/junit/JSONPointerTest.java
+++ b/src/test/java/org/json/junit/JSONPointerTest.java
@@ -1,8 +1,18 @@
 package org.json.junit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import org.json.*;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONPointer;
+import org.json.JSONPointerException;
+import org.json.JSONTokener;
 import org.junit.Test;
 
 public class JSONPointerTest {
@@ -10,8 +20,12 @@ public class JSONPointerTest {
     private static final JSONObject document;
 
     static {
-        document = new JSONObject(new JSONTokener(
-                JSONPointerTest.class.getClassLoader().getResourceAsStream("jsonpointer-testdoc.json")));
+        @SuppressWarnings("resource")
+        InputStream resourceAsStream = JSONPointerTest.class.getClassLoader().getResourceAsStream("jsonpointer-testdoc.json");
+        if(resourceAsStream == null) {
+            throw new ExceptionInInitializerError("Unable to locate test file. Please check your development environment configuration");
+        }
+        document = new JSONObject(new JSONTokener(resourceAsStream));
     }
 
     private Object query(String pointer) {

--- a/src/test/java/org/json/junit/JSONTokenerTest.java
+++ b/src/test/java/org/json/junit/JSONTokenerTest.java
@@ -1,6 +1,8 @@
 package org.json.junit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
@@ -121,7 +123,12 @@ public class JSONTokenerTest {
     @Test
     public void testNextBackComboWithNewLines() {
         final String testString = "this is\nA test\r\nWith some different\rNew Lines";
+        //                         ^       ^         ^                    ^
+        // index positions         0       8        16                   36
         final JSONTokener tokener = new JSONTokener(testString);
+        assertEquals(" at 0 [character 1 line 1]", tokener.toString());
+        assertEquals('t',tokener.next());
+        assertEquals(" at 1 [character 2 line 1]", tokener.toString());
         tokener.skipTo('\n');
         assertEquals("skipTo() improperly modifying indexes"," at 7 [character 8 line 1]", tokener.toString());
         assertEquals('\n',tokener.next());
@@ -132,10 +139,12 @@ public class JSONTokenerTest {
         assertEquals(" at 8 [character 0 line 2]", tokener.toString());
         tokener.skipTo('\r');
         assertEquals("skipTo() improperly modifying indexes"," at 14 [character 6 line 2]", tokener.toString());
+        // verify \r\n combo doesn't increment the line twice
         assertEquals('\r', tokener.next());
         assertEquals(" at 15 [character 0 line 3]", tokener.toString());
         assertEquals('\n', tokener.next());
         assertEquals(" at 16 [character 0 line 3]", tokener.toString());
+        // verify stepping back after reading the \n of an \r\n combo doesn't  increment the line incorrectly
         tokener.back();
         assertEquals(" at 15 [character 6 line 2]", tokener.toString());
         assertEquals('\n', tokener.next());
@@ -154,5 +163,39 @@ public class JSONTokenerTest {
         assertEquals(" at 36 [character 0 line 4]", tokener.toString());
         assertEquals('N', tokener.next());
         assertEquals(" at 37 [character 1 line 4]", tokener.toString());
+        
+        // verify we get the same data just walking though, no calls to back
+        final JSONTokener t2 = new JSONTokener(testString);
+        for(int i=0; i<7; i++) {
+            assertTrue(t2.toString().startsWith(" at " + i + " "));
+            assertEquals(testString.charAt(i), t2.next());
+        }
+        assertEquals(" at 7 [character 8 line 1]", t2.toString());
+        assertEquals(testString.charAt(7), t2.next());
+        assertEquals(" at 8 [character 0 line 2]", t2.toString());
+        for(int i=8; i<14; i++) {
+            assertTrue(t2.toString().startsWith(" at " + i + " "));
+            assertEquals(testString.charAt(i), t2.next());
+        }
+        assertEquals(" at 14 [character 6 line 2]", t2.toString());
+        assertEquals('\r', t2.next());
+        assertEquals(" at 15 [character 0 line 3]", t2.toString());
+        assertEquals('\n', t2.next());
+        assertEquals(" at 16 [character 0 line 3]", t2.toString());
+        assertEquals('W', t2.next());
+        assertEquals(" at 17 [character 1 line 3]", t2.toString());
+        for(int i=17; i<37; i++) {
+            assertTrue(t2.toString().startsWith(" at " + i + " "));
+            assertEquals(testString.charAt(i), t2.next());
+        }
+        assertEquals(" at 37 [character 1 line 4]", t2.toString());
+        for(int i=37; i<testString.length(); i++) {
+            assertTrue(t2.toString().startsWith(" at " + i + " "));
+            assertEquals(testString.charAt(i), t2.next());
+        }
+        assertEquals(" at "+ testString.length() +" [character 9 line 4]", t2.toString());
+        // end of the input
+        assertEquals(0, t2.next());
+        assertFalse(t2.more());
    }
 }

--- a/src/test/java/org/json/junit/JSONTokenerTest.java
+++ b/src/test/java/org/json/junit/JSONTokenerTest.java
@@ -1,0 +1,158 @@
+package org.json.junit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+
+import org.json.JSONException;
+import org.json.JSONTokener;
+import org.junit.Test;
+
+/**
+ * Test specific to the {@link org.json.JSONTokener} class.
+ * @author John Aylward
+ *
+ */
+public class JSONTokenerTest {
+
+    /**
+     * verify that back() fails as expected.
+     * @throws IOException thrown if something unexpected happens.
+     */
+    @Test
+    public void verifyBackFailureZeroIndex() throws IOException {
+        try(Reader reader = new StringReader("some test string")) {
+            final JSONTokener tokener = new JSONTokener(reader);
+            try {
+                // this should fail since the index is 0;
+                tokener.back();
+                fail("Expected an exception");
+            } catch (JSONException e) {
+                assertEquals("Stepping back two steps is not supported", e.getMessage());
+            } catch (Exception e) {
+                fail("Unknown Exception type " + e.getClass().getCanonicalName()+" with message "+e.getMessage());
+            }
+            
+        }
+    }
+    /**
+     * verify that back() fails as expected.
+     * @throws IOException thrown if something unexpected happens.
+     */
+    @Test
+    public void verifyBackFailureDoubleBack() throws IOException {
+        try(Reader reader = new StringReader("some test string")) {
+            final JSONTokener tokener = new JSONTokener(reader);
+            tokener.next();
+            tokener.back();
+            try {
+                // this should fail since the index is 0;
+                tokener.back();
+                fail("Expected an exception");
+            } catch (JSONException e) {
+                assertEquals("Stepping back two steps is not supported", e.getMessage());
+            } catch (Exception e) {
+                fail("Unknown Exception type " + e.getClass().getCanonicalName()+" with message "+e.getMessage());
+            }
+       }
+    }
+
+    /**
+     * Tests the failure of the skipTo method with a buffered reader. Preferably
+     * we'd like this not to fail but at this time we don't have a good recovery.
+     * 
+     * @throws IOException thrown if something unexpected happens.
+     */
+    @Test
+    public void testSkipToFailureWithBufferedReader() throws IOException {
+        final byte[] superLongBuffer = new byte[1000001];
+        // fill our buffer
+        for(int i=0;i<superLongBuffer.length;i++) {
+            superLongBuffer[i] = 'A';
+        }
+        try(Reader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(superLongBuffer)))) {
+            final JSONTokener tokener = new JSONTokener(reader);
+            try {
+                // this should fail since the internal markAhead buffer is only 1,000,000
+                // but 'B' doesn't exist in our buffer that is 1,000,001 in size
+                tokener.skipTo('B');
+                fail("Expected exception");
+            } catch (JSONException e) {
+                assertEquals("Mark invalid", e.getMessage());
+            } catch (Exception e) {
+                fail("Unknown Exception type " + e.getClass().getCanonicalName()+" with message "+e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Tests the success of the skipTo method with a String reader.
+     * 
+     * @throws IOException thrown if something unexpected happens.
+     */
+    @Test
+    public void testSkipToSuccessWithStringReader() throws IOException {
+        final StringBuilder superLongBuffer = new StringBuilder(1000001);
+        // fill our buffer
+        for(int i=0;i<superLongBuffer.length();i++) {
+            superLongBuffer.append('A');
+        }
+        try(Reader reader = new StringReader(superLongBuffer.toString())) {
+            final JSONTokener tokener = new JSONTokener(reader);
+            try {
+                // this should not fail since the internal markAhead is ignored for StringReaders
+                tokener.skipTo('B');
+            } catch (Exception e) {
+                fail("Unknown Exception type " + e.getClass().getCanonicalName()+" with message "+e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Verify that next and back are working properly and tracking the correct positions
+     * with different new line combinations.
+     */
+    @Test
+    public void testNextBackComboWithNewLines() {
+        final String testString = "this is\nA test\r\nWith some different\rNew Lines";
+        final JSONTokener tokener = new JSONTokener(testString);
+        tokener.skipTo('\n');
+        assertEquals("skipTo() improperly modifying indexes"," at 7 [character 8 line 1]", tokener.toString());
+        assertEquals('\n',tokener.next());
+        assertEquals(" at 8 [character 0 line 2]", tokener.toString());
+        assertEquals('A',tokener.next());
+        assertEquals(" at 9 [character 1 line 2]", tokener.toString());
+        tokener.back();
+        assertEquals(" at 8 [character 0 line 2]", tokener.toString());
+        tokener.skipTo('\r');
+        assertEquals("skipTo() improperly modifying indexes"," at 14 [character 6 line 2]", tokener.toString());
+        assertEquals('\r', tokener.next());
+        assertEquals(" at 15 [character 0 line 3]", tokener.toString());
+        assertEquals('\n', tokener.next());
+        assertEquals(" at 16 [character 0 line 3]", tokener.toString());
+        tokener.back();
+        assertEquals(" at 15 [character 6 line 2]", tokener.toString());
+        assertEquals('\n', tokener.next());
+        assertEquals(" at 16 [character 0 line 3]", tokener.toString());
+        assertEquals('W', tokener.next());
+        assertEquals(" at 17 [character 1 line 3]", tokener.toString());
+        assertEquals('i', tokener.next());
+        assertEquals(" at 18 [character 2 line 3]", tokener.toString());
+        tokener.skipTo('\r');
+        assertEquals("skipTo() improperly modifying indexes"," at 35 [character 19 line 3]", tokener.toString());
+        assertEquals('\r', tokener.next());
+        assertEquals(" at 36 [character 0 line 4]", tokener.toString());
+        tokener.back();
+        assertEquals(" at 35 [character 19 line 3]", tokener.toString());
+        assertEquals('\r', tokener.next());
+        assertEquals(" at 36 [character 0 line 4]", tokener.toString());
+        assertEquals('N', tokener.next());
+        assertEquals(" at 37 [character 1 line 4]", tokener.toString());
+   }
+}

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -103,7 +103,7 @@ public class XMLTest {
             fail("Expecting a JSONException");
         } catch (JSONException e) {
             assertEquals("Expecting an exception message",
-                    "Misshaped meta tag at 215 [character 13 line 7]",
+                    "Misshaped meta tag at 214 [character 12 line 7]",
                     e.getMessage());
         }
     }
@@ -128,7 +128,7 @@ public class XMLTest {
             fail("Expecting a JSONException");
         } catch (JSONException e) {
             assertEquals("Expecting an exception message",
-                    "Misshaped meta tag at 214 [character 13 line 7]",
+                    "Misshaped meta tag at 213 [character 12 line 7]",
                     e.getMessage());
         }
     }

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -3,6 +3,7 @@ package org.json.junit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -74,11 +75,11 @@ public class XMLTest {
             "</addresses>";
         try {
             XML.toJSONObject(xmlStr);
-            assertTrue("Expecting a JSONException", false);
+            fail("Expecting a JSONException");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                    "Misshaped tag at 176 [character 14 line 5]".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                    "Misshaped tag at 176 [character 14 line 4]",
+                    e.getMessage());
         }
     }
 
@@ -99,11 +100,11 @@ public class XMLTest {
             "</addresses>";
         try {
             XML.toJSONObject(xmlStr);
-            assertTrue("Expecting a JSONException", false);
+            fail("Expecting a JSONException");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                    "Misshaped meta tag at 215 [character 13 line 8]".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                    "Misshaped meta tag at 215 [character 13 line 7]",
+                    e.getMessage());
         }
     }
 
@@ -124,11 +125,11 @@ public class XMLTest {
             "</addresses>";
         try {
             XML.toJSONObject(xmlStr);
-            assertTrue("Expecting a JSONException", false);
+            fail("Expecting a JSONException");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                    "Misshaped meta tag at 214 [character 13 line 8]".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                    "Misshaped meta tag at 214 [character 13 line 7]",
+                    e.getMessage());
         }
     }
 
@@ -149,11 +150,11 @@ public class XMLTest {
             "</addresses>";
         try {
             XML.toJSONObject(xmlStr);
-            assertTrue("Expecting a JSONException", false);
+            fail("Expecting a JSONException");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                    "Misplaced '<' at 193 [character 4 line 7]".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                    "Misplaced '<' at 193 [character 4 line 6]",
+                    e.getMessage());
         }
     }
 
@@ -174,11 +175,11 @@ public class XMLTest {
             "</addresses>";
         try {
             XML.toJSONObject(xmlStr);
-            assertTrue("Expecting a JSONException", false);
+            fail("Expecting a JSONException");
         } catch (JSONException e) {
-            assertTrue("Expecting an exception message",
-                    "Expected 'CDATA[' at 204 [character 11 line 6]".
-                    equals(e.getMessage()));
+            assertEquals("Expecting an exception message",
+                    "Expected 'CDATA[' at 204 [character 11 line 5]",
+                    e.getMessage());
         }
     }
 
@@ -397,9 +398,9 @@ public class XMLTest {
 
         final String expected = "<jo></jo>";
         String output1 = XML.toString(jo1,"jo");
-        assertTrue("Expected an empty root tag", expected.equals(output1));
+        assertEquals("Expected an empty root tag", expected, output1);
         String output2 = XML.toString(jo2,"jo");
-        assertTrue("Expected an empty root tag", expected.equals(output2));
+        assertEquals("Expected an empty root tag", expected, output2);
     }
     
     /**
@@ -414,9 +415,9 @@ public class XMLTest {
 
         final String expected = "<jo><arr>One</arr><arr></arr><arr>Four</arr></jo>";
         String output1 = XML.toString(jo1,"jo");
-        assertTrue("Expected a matching array", expected.equals(output1));
+        assertEquals("Expected a matching array", expected, output1);
         String output2 = XML.toString(jo2,"jo");
-        assertTrue("Expected a matching array", expected.equals(output2));
+        assertEquals("Expected a matching array", expected, output2);
     }
    
     /**
@@ -431,9 +432,9 @@ public class XMLTest {
 
         final String expected = "<jo><arr>One</arr><arr>Two</arr><arr>Three</arr></jo>";
         String output1 = XML.toString(jo1,"jo");
-        assertTrue("Expected a non empty root tag", expected.equals(output1));
+        assertEquals("Expected a non empty root tag", expected, output1);
         String output2 = XML.toString(jo2,"jo");
-        assertTrue("Expected a non empty root tag", expected.equals(output2));
+        assertEquals("Expected a non empty root tag", expected, output2);
     }
 
     /**
@@ -448,9 +449,9 @@ public class XMLTest {
 
         final String expected = "<jo><arr>One</arr><arr><array>Two</array><array>Three</array></arr><arr>Four</arr></jo>";
         String output1 = XML.toString(jo1,"jo");
-        assertTrue("Expected a matching array", expected.equals(output1));
+        assertEquals("Expected a matching array", expected, output1);
         String output2 = XML.toString(jo2,"jo");
-        assertTrue("Expected a matching array", expected.equals(output2));
+        assertEquals("Expected a matching array", expected, output2);
     }
 
     /**


### PR DESCRIPTION
see https://github.com/stleary/JSON-java/pull/352 or 
https://github.com/stleary/JSON-java/pull/350 for the changes from PR 352 plus android support changes.

The current tests on Master are verifying error messages from the tokeners, but using incorrect position information. This PR corrects the position information in the tests, as well as adds new tests to verify position information.

This PR will fail on the current master branch of JSON-Java until one of the above mentioned PR for JSON-Java are merged.