### PR TITLE
improve the confused assert message

### DIFF
--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -593,15 +593,20 @@ public class JSONObjectTest {
                 jsonObject.has("someFloat"));
         assertFalse("Ignored field not found!",
                 jsonObject.has("ignoredInt"));
-        assertTrue("Normal field name (someInt) found",
+        // getSomeInt() has no user-defined annotation
+        assertTrue("Normal field name (someInt) should have been found",
                 jsonObject.has("someInt"));
-        assertTrue("Normal field name (someLong) found",
+        // the user-defined annotation does not replace any value, so someLong should be found
+        assertTrue("Normal field name (someLong) should have been found",
                 jsonObject.has("someLong"));
-        assertTrue("Overridden String field name (myStringField) found",
+        // myStringField replaces someString property name via user-defined annotation
+        assertTrue("Overridden String field name (myStringField) should have been found",
                 jsonObject.has("myStringField"));
-        assertTrue("Overridden String field name (Some Weird NAme that Normally Wouldn't be possible!) found",
+        // weird name replaces myDouble property name via user-defined annotation
+        assertTrue("Overridden String field name (Some Weird NAme that Normally Wouldn't be possible!) should have been found",
                 jsonObject.has("Some Weird NAme that Normally Wouldn't be possible!"));
-        assertTrue("Overridden String field name (InterfaceField) found",
+        // InterfaceField replaces someFloat property name via user-defined annotation
+        assertTrue("Overridden String field name (InterfaceField) should have been found",
                 jsonObject.has("InterfaceField"));
     }
     
@@ -619,29 +624,39 @@ public class JSONObjectTest {
                 jsonObject.has("someInt"));
         assertFalse("Normal field name (myDouble) processing did not work",
                 jsonObject.has("myDouble"));
-        assertFalse("Overridden String field name (Some Weird NAme that Normally Wouldn't be possible!) not FOUND!",
+        // myDouble was replaced by weird name, and then replaced again by AMoreNormalName via user-defined annotation
+        assertFalse("Overridden String field name (Some Weird NAme that Normally Wouldn't be possible!) should not be FOUND!",
                 jsonObject.has("Some Weird NAme that Normally Wouldn't be possible!"));
         assertFalse("Normal field name (someFloat) found, but was overridden",
                 jsonObject.has("someFloat"));
         assertFalse("Ignored field found! but was overridden",
                 jsonObject.has("ignoredInt"));
-        assertFalse("Ignored field at the same level as forced name not found",
+        // shouldNotBeJSON property name was first ignored, then replaced by ShouldBeIgnored via user-defined annotations
+        assertFalse("Ignored field at the same level as forced name should not have been found",
                 jsonObject.has("ShouldBeIgnored"));
-        assertFalse("Normally ignored field (able) with explicit property name not found",
+        // able property name was replaced by Getable via user-defined annotation
+        assertFalse("Normally ignored field (able) with explicit property name should not have been found",
                 jsonObject.has("able"));
-        assertTrue("Overridden int field name (newIntFieldName) found",
+        // property name someInt was replaced by newIntFieldName via user-defined annotation
+        assertTrue("Overridden int field name (newIntFieldName) should have been found",
                 jsonObject.has("newIntFieldName"));
-        assertTrue("Normal field name (someLong) found",
+        // property name someLong was not replaced via user-defined annotation
+        assertTrue("Normal field name (someLong) should have been found",
                 jsonObject.has("someLong"));
-        assertTrue("Overridden String field name (myStringField) found",
+        // property name someString was replaced by myStringField via user-defined annotation
+        assertTrue("Overridden String field name (myStringField) should have been found",
                 jsonObject.has("myStringField"));
-        assertTrue("Overridden double field name (AMoreNormalName) found",
+        // property name myDouble was replaced by a weird name, followed by AMoreNormalName via user-defined annotations
+        assertTrue("Overridden double field name (AMoreNormalName) should have been found",
                 jsonObject.has("AMoreNormalName"));
-        assertTrue("Overridden String field name (InterfaceField) found",
+        // property name someFloat was replaced by InterfaceField via user-defined annotation
+        assertTrue("Overridden String field name (InterfaceField) should have been found",
                 jsonObject.has("InterfaceField"));
-        assertTrue("Forced field found!",
+        // property name ignoredInt was replaced by none, followed by forcedInt via user-defined annotations
+        assertTrue("Forced field should have been found!",
                 jsonObject.has("forcedInt"));
-        assertTrue("Overridden boolean field name (Getable) found",
+        // property name able was replaced by Getable via user-defined annotation
+        assertTrue("Overridden boolean field name (Getable) should have been found",
                 jsonObject.has("Getable"));
     }
 

--- a/src/test/java/org/json/junit/JSONObjectTest.java
+++ b/src/test/java/org/json/junit/JSONObjectTest.java
@@ -589,19 +589,19 @@ public class JSONObjectTest {
                 jsonObject.has("someString"));
         assertFalse("Normal field name (myDouble) processing did not work",
                 jsonObject.has("myDouble"));
-        assertFalse("Normal field name (someFloat) found",
+        assertFalse("Normal field name (someFloat) processing did not work",
                 jsonObject.has("someFloat"));
-        assertFalse("Ignored field found!",
+        assertFalse("Ignored field not found!",
                 jsonObject.has("ignoredInt"));
-        assertTrue("Normal field name (someInt) processing did not work",
+        assertTrue("Normal field name (someInt) found",
                 jsonObject.has("someInt"));
-        assertTrue("Normal field name (someLong) processing did not work",
+        assertTrue("Normal field name (someLong) found",
                 jsonObject.has("someLong"));
-        assertTrue("Overridden String field name (myStringField) not found",
+        assertTrue("Overridden String field name (myStringField) found",
                 jsonObject.has("myStringField"));
-        assertTrue("Overridden String field name (Some Weird NAme that Normally Wouldn't be possible!) not found",
+        assertTrue("Overridden String field name (Some Weird NAme that Normally Wouldn't be possible!) found",
                 jsonObject.has("Some Weird NAme that Normally Wouldn't be possible!"));
-        assertTrue("Overridden String field name (InterfaceField) not found",
+        assertTrue("Overridden String field name (InterfaceField) found",
                 jsonObject.has("InterfaceField"));
     }
     
@@ -619,26 +619,29 @@ public class JSONObjectTest {
                 jsonObject.has("someInt"));
         assertFalse("Normal field name (myDouble) processing did not work",
                 jsonObject.has("myDouble"));
-        assertFalse("Overridden String field name (Some Weird NAme that Normally Wouldn't be possible!) FOUND!",
+        assertFalse("Overridden String field name (Some Weird NAme that Normally Wouldn't be possible!) not FOUND!",
                 jsonObject.has("Some Weird NAme that Normally Wouldn't be possible!"));
-        assertFalse("Normal field name (someFloat) found",
+        assertFalse("Normal field name (someFloat) found, but was overridden",
                 jsonObject.has("someFloat"));
-        assertFalse("Ignored field found!",
+        assertFalse("Ignored field found! but was overridden",
                 jsonObject.has("ignoredInt"));
-        assertFalse("Ignored field at the same level as forced name found",
+        assertFalse("Ignored field at the same level as forced name not found",
                 jsonObject.has("ShouldBeIgnored"));
-        assertTrue("Overridden int field name (newIntFieldName) not found",
+        assertFalse("Normally ignored field (able) with explicit property name not found",
+                jsonObject.has("able"));
+        assertTrue("Overridden int field name (newIntFieldName) found",
                 jsonObject.has("newIntFieldName"));
-        assertTrue("Normal field name (someLong) processing did not work",
+        assertTrue("Normal field name (someLong) found",
                 jsonObject.has("someLong"));
-        assertTrue("Overridden String field name (myStringField) not found",
+        assertTrue("Overridden String field name (myStringField) found",
                 jsonObject.has("myStringField"));
-        assertTrue(jsonObject.has("AMoreNormalName"));
-        assertTrue("Overridden String field name (InterfaceField) not found",
+        assertTrue("Overridden double field name (AMoreNormalName) found",
+                jsonObject.has("AMoreNormalName"));
+        assertTrue("Overridden String field name (InterfaceField) found",
                 jsonObject.has("InterfaceField"));
-        assertTrue("Forced field not found!",
+        assertTrue("Forced field found!",
                 jsonObject.has("forcedInt"));
-        assertTrue("Normally ignored field (getable) with explicit property name not found",
+        assertTrue("Overridden boolean field name (Getable) found",
                 jsonObject.has("Getable"));
     }
 


### PR DESCRIPTION
The test cases for bean parse are good, but some assert messages make people coufused, some fields are found but described as not working, while another fields are not found but described as found.